### PR TITLE
feat: Docker Hub publishing and badge updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            willluck/docker-sentinel
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![CI](https://github.com/Will-Luck/Docker-Sentinel/actions/workflows/release.yml/badge.svg)](https://github.com/Will-Luck/Docker-Sentinel/actions/workflows/release.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/Will-Luck/Docker-Sentinel)](https://github.com/Will-Luck/Docker-Sentinel/releases/latest)
+[![Docker Pulls](https://img.shields.io/docker/pulls/willluck/docker-sentinel)](https://hub.docker.com/r/willluck/docker-sentinel)
 [![Downloads](https://img.shields.io/github/downloads/Will-Luck/Docker-Sentinel/total)](https://github.com/Will-Luck/Docker-Sentinel/releases)
-[![Pull Requests](https://img.shields.io/github/issues-pr-closed/Will-Luck/Docker-Sentinel?label=PRs%20merged&color=blueviolet)](https://github.com/Will-Luck/Docker-Sentinel/pulls?q=is%3Apr+is%3Amerged)
+[![Last Commit](https://img.shields.io/github/last-commit/Will-Luck/Docker-Sentinel)](https://github.com/Will-Luck/Docker-Sentinel/commits)
 [![GHCR](https://img.shields.io/badge/ghcr.io-docker--sentinel-blue?logo=github)](https://github.com/Will-Luck/Docker-Sentinel/pkgs/container/docker-sentinel)
 
 A container update orchestrator with a web dashboard, written in Go. Replaces Watchtower with per-container update policies, pre-update snapshots, post-update health validation, automatic rollback, and real-time notifications.
@@ -22,6 +23,7 @@ A container update orchestrator with a web dashboard, written in Go. Replaces Wa
 ## Quick Start
 
 ```bash
+# From Docker Hub
 docker run -d \
   --name docker-sentinel \
   --restart unless-stopped \
@@ -29,7 +31,10 @@ docker run -d \
   -v sentinel-data:/data \
   -p 8080:8080 \
   -e SENTINEL_POLL_INTERVAL=6h \
-  ghcr.io/will-luck/docker-sentinel:latest
+  willluck/docker-sentinel:latest
+
+# Or from GitHub Container Registry
+# ghcr.io/will-luck/docker-sentinel:latest
 ```
 
 Then open `http://localhost:8080` in your browser.


### PR DESCRIPTION
## Summary
- Release workflow now pushes images to both GHCR and Docker Hub (`willluck/docker-sentinel`)
- Added Docker Pulls and Last Commit badges to README
- Docker Hub is now the primary install option in Quick Start

## Test plan
- [ ] Next `v*` tag push will publish to both registries
- [ ] Docker Hub repo created at https://hub.docker.com/r/willluck/docker-sentinel

🤖 Generated with [Claude Code](https://claude.com/claude-code)