### PR TITLE
feat: Settings page overhaul with runtime controls

### DIFF
--- a/internal/notify/filtered.go
+++ b/internal/notify/filtered.go
@@ -1,0 +1,34 @@
+package notify
+
+import "context"
+
+// filteredNotifier wraps a Notifier and only forwards events whose type
+// matches the allowed set. If the allowed set is empty, all events pass through.
+type filteredNotifier struct {
+	inner   Notifier
+	allowed map[EventType]struct{}
+}
+
+// newFilteredNotifier creates a notifier that only forwards events matching
+// the given event type strings. An empty list means all events are forwarded.
+func newFilteredNotifier(inner Notifier, events []string) *filteredNotifier {
+	allowed := make(map[EventType]struct{}, len(events))
+	for _, e := range events {
+		allowed[EventType(e)] = struct{}{}
+	}
+	return &filteredNotifier{inner: inner, allowed: allowed}
+}
+
+// Name returns the name of the wrapped notifier.
+func (f *filteredNotifier) Name() string { return f.inner.Name() }
+
+// Send forwards the event to the inner notifier only if the event type
+// is in the allowed set.
+func (f *filteredNotifier) Send(ctx context.Context, event Event) error {
+	if len(f.allowed) > 0 {
+		if _, ok := f.allowed[event.Type]; !ok {
+			return nil
+		}
+	}
+	return f.inner.Send(ctx, event)
+}

--- a/internal/notify/filtered_test.go
+++ b/internal/notify/filtered_test.go
@@ -1,0 +1,123 @@
+package notify
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFilteredNotifierAllowsMatchingEvents(t *testing.T) {
+	inner := &stubNotifier{name: "test"}
+	f := newFilteredNotifier(inner, []string{"update_available", "update_failed"})
+
+	// Should be forwarded.
+	if err := f.Send(context.Background(), testEvent(EventUpdateAvailable)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if len(inner.sent) != 1 {
+		t.Fatalf("got %d events, want 1", len(inner.sent))
+	}
+
+	// Should also be forwarded.
+	if err := f.Send(context.Background(), testEvent(EventUpdateFailed)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if len(inner.sent) != 2 {
+		t.Fatalf("got %d events, want 2", len(inner.sent))
+	}
+}
+
+func TestFilteredNotifierBlocksNonMatchingEvents(t *testing.T) {
+	inner := &stubNotifier{name: "test"}
+	f := newFilteredNotifier(inner, []string{"update_available"})
+
+	// Should be blocked.
+	if err := f.Send(context.Background(), testEvent(EventUpdateSucceeded)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if len(inner.sent) != 0 {
+		t.Fatalf("got %d events, want 0 (should be filtered out)", len(inner.sent))
+	}
+}
+
+func TestFilteredNotifierEmptyFilterAllowsAll(t *testing.T) {
+	inner := &stubNotifier{name: "test"}
+	f := newFilteredNotifier(inner, []string{})
+
+	// All events should pass through.
+	if err := f.Send(context.Background(), testEvent(EventUpdateAvailable)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if err := f.Send(context.Background(), testEvent(EventUpdateSucceeded)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if err := f.Send(context.Background(), testEvent(EventRollbackOK)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if len(inner.sent) != 3 {
+		t.Fatalf("got %d events, want 3 (empty filter should pass all)", len(inner.sent))
+	}
+}
+
+func TestFilteredNotifierNilFilterAllowsAll(t *testing.T) {
+	inner := &stubNotifier{name: "test"}
+	f := newFilteredNotifier(inner, nil)
+
+	if err := f.Send(context.Background(), testEvent(EventUpdateFailed)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if len(inner.sent) != 1 {
+		t.Fatalf("got %d events, want 1 (nil filter should pass all)", len(inner.sent))
+	}
+}
+
+func TestFilteredNotifierPreservesName(t *testing.T) {
+	inner := &stubNotifier{name: "gotify"}
+	f := newFilteredNotifier(inner, []string{"update_available"})
+
+	if f.Name() != "gotify" {
+		t.Errorf("Name() = %q, want %q", f.Name(), "gotify")
+	}
+}
+
+func TestBuildFilteredNotifierWithEvents(t *testing.T) {
+	settings := []byte(`{"url":"http://example.com","token":"tok"}`)
+	ch := Channel{
+		ID:       "test-1",
+		Type:     ProviderGotify,
+		Name:     "Gotify",
+		Enabled:  true,
+		Settings: settings,
+		Events:   []string{"update_available", "update_failed"},
+	}
+
+	n, err := BuildFilteredNotifier(ch)
+	if err != nil {
+		t.Fatalf("BuildFilteredNotifier() error = %v", err)
+	}
+
+	// Should be a filteredNotifier wrapping gotify.
+	if _, ok := n.(*filteredNotifier); !ok {
+		t.Errorf("expected *filteredNotifier, got %T", n)
+	}
+}
+
+func TestBuildFilteredNotifierWithoutEvents(t *testing.T) {
+	settings := []byte(`{"url":"http://example.com","token":"tok"}`)
+	ch := Channel{
+		ID:       "test-2",
+		Type:     ProviderGotify,
+		Name:     "Gotify",
+		Enabled:  true,
+		Settings: settings,
+	}
+
+	n, err := BuildFilteredNotifier(ch)
+	if err != nil {
+		t.Fatalf("BuildFilteredNotifier() error = %v", err)
+	}
+
+	// Should be a plain Gotify notifier (no filter wrapper).
+	if _, ok := n.(*Gotify); !ok {
+		t.Errorf("expected *Gotify (no filter), got %T", n)
+	}
+}

--- a/internal/notify/notifier.go
+++ b/internal/notify/notifier.go
@@ -18,7 +18,21 @@ const (
 	EventRollbackOK       EventType = "rollback_succeeded"
 	EventRollbackFailed   EventType = "rollback_failed"
 	EventVersionAvailable EventType = "version_available"
+	EventContainerState   EventType = "container_state"
 )
+
+// AllEventTypes returns all event types that can be filtered for notifications.
+func AllEventTypes() []EventType {
+	return []EventType{
+		EventUpdateAvailable,
+		EventUpdateStarted,
+		EventUpdateSucceeded,
+		EventUpdateFailed,
+		EventRollbackOK,
+		EventRollbackFailed,
+		EventContainerState,
+	}
+}
 
 // Event represents a notification event.
 type Event struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -108,6 +108,7 @@ type SchedulerController interface {
 type SettingsStore interface {
 	SaveSetting(key, value string) error
 	LoadSetting(key string) (string, error)
+	GetAllSettings() (map[string]string, error)
 }
 
 // LogEntry mirrors store.LogEntry.
@@ -300,6 +301,10 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /api/containers/{name}/restart", s.apiRestart)
 	s.mux.HandleFunc("GET /api/settings", s.apiSettings)
 	s.mux.HandleFunc("POST /api/settings/poll-interval", s.apiSetPollInterval)
+	s.mux.HandleFunc("POST /api/settings/default-policy", s.apiSetDefaultPolicy)
+	s.mux.HandleFunc("POST /api/settings/grace-period", s.apiSetGracePeriod)
+	s.mux.HandleFunc("POST /api/settings/pause", s.apiSetPause)
+	s.mux.HandleFunc("POST /api/settings/filters", s.apiSetFilters)
 	s.mux.HandleFunc("GET /api/logs", s.apiLogs)
 	s.mux.HandleFunc("POST /api/self-update", s.apiSelfUpdate)
 	s.mux.HandleFunc("POST /api/containers/{name}/stop", s.apiStop)
@@ -307,6 +312,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/settings/notifications", s.apiGetNotifications)
 	s.mux.HandleFunc("PUT /api/settings/notifications", s.apiSaveNotifications)
 	s.mux.HandleFunc("POST /api/settings/notifications/test", s.apiTestNotification)
+	s.mux.HandleFunc("GET /api/settings/notifications/event-types", s.apiNotificationEventTypes)
 
 	// Per-container HTML partial (for live row updates).
 	s.mux.HandleFunc("GET /api/containers/{name}/row", s.handleContainerRow)

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -54,6 +54,11 @@
             </div>
         </dl>
 
+        <div id="pause-banner" class="pause-banner" style="display:none">
+            <span>Scanning is paused</span>
+            <button class="btn btn-warning" onclick="resumeScanning()">Resume</button>
+        </div>
+
         <div class="card">
             <div class="card-header">
                 <h2>Container Status</h2>

--- a/internal/web/static/settings.html
+++ b/internal/web/static/settings.html
@@ -40,17 +40,16 @@
         </div>
 
         <div class="tab-nav" role="tablist">
-            <button class="tab-btn active" role="tab" aria-selected="true" aria-controls="tab-schedule" data-tab="schedule">Update Schedule</button>
-            <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-appearance" data-tab="appearance">Appearance</button>
+            <button class="tab-btn active" role="tab" aria-selected="true" aria-controls="tab-general" data-tab="general">General</button>
             <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-notifications" data-tab="notifications">Notifications</button>
-            <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-server" data-tab="server">Server Config</button>
+            <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-appearance" data-tab="appearance">Appearance</button>
         </div>
 
-        <!-- Update Schedule tab -->
-        <div class="tab-panel active" id="tab-schedule" role="tabpanel">
+        <!-- General tab -->
+        <div class="tab-panel active" id="tab-general" role="tabpanel">
             <div class="settings-grid">
                 <div class="card">
-                    <div class="card-header"><h2>Scanning</h2></div>
+                    <div class="card-header"><h2>Scanning &amp; Behaviour</h2></div>
                     <div class="card-body">
                         <div class="setting-row">
                             <div class="setting-info">
@@ -67,41 +66,102 @@
                                     <option value="24h">24 hours</option>
                                     <option value="custom">Custom...</option>
                                 </select>
-                                <input id="poll-custom" type="text" class="setting-select" placeholder="e.g. 2h30m" style="display:none;margin-top:var(--sp-2)">
-                                <button id="poll-custom-btn" class="btn btn-success" style="display:none;margin-top:var(--sp-2)" onclick="applyCustomPollInterval()">Apply</button>
+                                <div id="poll-custom-wrap" class="custom-duration-wrap" style="display:none">
+                                    <select id="poll-custom-unit" class="setting-select custom-duration-unit" onchange="onCustomUnitChange('poll')">
+                                        <option value="">Unit...</option>
+                                        <option value="s">Seconds</option>
+                                        <option value="m">Minutes</option>
+                                        <option value="h">Hours</option>
+                                    </select>
+                                    <input id="poll-custom-value" type="number" class="setting-select custom-duration-value" min="1" placeholder="Value" disabled>
+                                    <button id="poll-custom-btn" class="btn btn-success" onclick="applyCustomPollInterval()" disabled>Apply</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Default policy</div>
+                                <div class="setting-desc">Policy assigned to containers without a sentinel.policy label</div>
+                            </div>
+                            <select id="default-policy" class="setting-select" onchange="setDefaultPolicy(this.value)">
+                                <option value="auto">auto</option>
+                                <option value="manual">manual</option>
+                                <option value="pinned">pinned</option>
+                            </select>
+                        </div>
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Grace period</div>
+                                <div class="setting-desc">Time to wait after an update before checking container health</div>
+                            </div>
+                            <div class="poll-interval-control">
+                                <select id="grace-period" class="setting-select" onchange="onGracePeriodChange(this.value)">
+                                    <option value="10s">10 seconds</option>
+                                    <option value="15s">15 seconds</option>
+                                    <option value="30s">30 seconds</option>
+                                    <option value="1m0s">60 seconds</option>
+                                    <option value="2m0s">120 seconds</option>
+                                    <option value="custom">Custom...</option>
+                                </select>
+                                <div id="grace-custom-wrap" class="custom-duration-wrap" style="display:none">
+                                    <select id="grace-custom-unit" class="setting-select custom-duration-unit" onchange="onCustomUnitChange('grace')">
+                                        <option value="">Unit...</option>
+                                        <option value="s">Seconds</option>
+                                        <option value="m">Minutes</option>
+                                        <option value="h">Hours</option>
+                                    </select>
+                                    <input id="grace-custom-value" type="number" class="setting-select custom-duration-value" min="1" placeholder="Value" disabled>
+                                    <button id="grace-custom-btn" class="btn btn-success" onclick="applyCustomGracePeriod()" disabled>Apply</button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Pause scanning</div>
+                                <div class="setting-desc">Temporarily stop all automatic update checks</div>
+                            </div>
+                            <label class="toggle-switch-label">
+                                <input type="checkbox" id="pause-toggle" class="channel-toggle" onchange="setPauseState(this.checked)">
+                                <span id="pause-toggle-text" class="toggle-switch-text">Off</span>
+                            </label>
+                        </div>
+                        <div class="setting-row setting-row-top">
+                            <div class="setting-info">
+                                <div class="setting-label">Container filters</div>
+                                <div class="setting-desc">Exclude containers matching these patterns (one per line)</div>
+                            </div>
+                            <div class="setting-control-stack">
+                                <textarea id="container-filters" class="setting-textarea" placeholder="e.g. watchtower&#10;test-*"></textarea>
+                                <button class="btn btn-success" onclick="saveFilters()">Save Filters</button>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
 
-        <!-- Appearance tab -->
-        <div class="tab-panel" id="tab-appearance" role="tabpanel">
-            <div class="settings-grid">
-                <div class="card">
-                    <div class="card-header"><h2>Appearance</h2></div>
-                    <div class="card-body">
-                        <div class="setting-row">
-                            <div class="setting-info">
-                                <div class="setting-label">Theme</div>
-                                <div class="setting-desc">Choose your colour scheme</div>
+                <!-- Collapsible Environment Variables -->
+                <div class="collapsible-section">
+                    <button class="collapsible-header" onclick="toggleCollapsible(this)" aria-expanded="false">
+                        <span class="collapsible-chevron">&#9656;</span>
+                        <span>Environment Variables</span>
+                        <span class="setting-desc" style="margin-left:var(--sp-2);margin-bottom:0">Read-only values set via environment</span>
+                    </button>
+                    <div class="collapsible-body" style="display:none">
+                        <div class="card" style="border-top-left-radius:0;border-top-right-radius:0">
+                            <div class="card-body">
+                                <div class="table-wrap">
+                                    <table class="table-readonly">
+                                        <thead><tr><th>Setting</th><th>Value</th></tr></thead>
+                                        <tbody>
+                                            {{range $k, $v := .Settings}}
+                                            <tr>
+                                                <td class="mono">{{$k}}</td>
+                                                <td class="mono">{{$v}}</td>
+                                            </tr>
+                                            {{end}}
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
-                            <select id="theme-select" class="setting-select">
-                                <option value="auto">Auto (system)</option>
-                                <option value="dark">Dark</option>
-                                <option value="light">Light</option>
-                            </select>
-                        </div>
-                        <div class="setting-row">
-                            <div class="setting-info">
-                                <div class="setting-label">Default stack view</div>
-                                <div class="setting-desc">Whether stacks start collapsed or expanded on the dashboard</div>
-                            </div>
-                            <select id="stack-default" class="setting-select">
-                                <option value="collapsed">Collapsed</option>
-                                <option value="expanded">Expanded</option>
-                            </select>
                         </div>
                     </div>
                 </div>
@@ -132,25 +192,32 @@
             </div>
         </div>
 
-        <!-- Server Config tab -->
-        <div class="tab-panel" id="tab-server" role="tabpanel">
+        <!-- Appearance tab -->
+        <div class="tab-panel" id="tab-appearance" role="tabpanel">
             <div class="settings-grid">
                 <div class="card">
-                    <div class="card-header"><h2>Server Configuration</h2></div>
+                    <div class="card-header"><h2>Appearance</h2></div>
                     <div class="card-body">
-                        <p class="subtitle" style="margin-bottom: var(--sp-4)">These are set via environment variables and cannot be changed from the dashboard.</p>
-                        <div class="table-wrap">
-                            <table class="table-readonly">
-                                <thead><tr><th>Setting</th><th>Value</th></tr></thead>
-                                <tbody>
-                                    {{range $k, $v := .Settings}}
-                                    <tr>
-                                        <td class="mono">{{$k}}</td>
-                                        <td class="mono">{{$v}}</td>
-                                    </tr>
-                                    {{end}}
-                                </tbody>
-                            </table>
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Theme</div>
+                                <div class="setting-desc">Choose your colour scheme</div>
+                            </div>
+                            <select id="theme-select" class="setting-select">
+                                <option value="auto">Auto (system)</option>
+                                <option value="dark">Dark</option>
+                                <option value="light">Light</option>
+                            </select>
+                        </div>
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Default stack view</div>
+                                <div class="setting-desc">Whether stacks start collapsed or expanded on the dashboard</div>
+                            </div>
+                            <select id="stack-default" class="setting-select">
+                                <option value="collapsed">Collapsed</option>
+                                <option value="expanded">Expanded</option>
+                            </select>
                         </div>
                     </div>
                 </div>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -1546,6 +1546,199 @@ td:nth-child(6) {
 
 
 /* --------------------------------------------------------------------------
+   20a. Pause Banner — dashboard warning when scanning is paused
+   -------------------------------------------------------------------------- */
+
+.pause-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--sp-4);
+    padding: var(--sp-3) var(--sp-5);
+    margin-bottom: var(--sp-6);
+    background: var(--warning-bg);
+    border: 1px solid var(--warning);
+    border-radius: var(--radius-lg);
+    color: var(--warning-fg);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+
+/* --------------------------------------------------------------------------
+   20b. Event Filter Pills — toggle chips for notification event types
+   -------------------------------------------------------------------------- */
+
+.event-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: var(--sp-3);
+    padding-top: var(--sp-3);
+    border-top: 1px solid var(--border);
+}
+
+.event-pills-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--fg-secondary);
+    width: 100%;
+    margin-bottom: 2px;
+}
+
+.event-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 10px;
+    border-radius: var(--radius-full);
+    font-size: 0.7rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 150ms, color 150ms, border-color 150ms;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--fg-muted);
+    user-select: none;
+}
+
+.event-pill:hover {
+    border-color: var(--border-strong);
+    color: var(--fg-secondary);
+}
+
+.event-pill.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #ffffff;
+}
+
+
+/* --------------------------------------------------------------------------
+   20c. Collapsible Section — expandable env vars on settings page
+   -------------------------------------------------------------------------- */
+
+.collapsible-section {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+}
+
+.collapsible-header {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    width: 100%;
+    padding: var(--sp-3) var(--sp-5);
+    background: var(--bg-surface);
+    border: none;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--fg-primary);
+    text-align: left;
+    transition: background 150ms;
+}
+
+.collapsible-header:hover {
+    background: var(--bg-hover);
+}
+
+.collapsible-chevron {
+    font-size: 0.8rem;
+    color: var(--fg-secondary);
+    transition: transform 200ms;
+    display: inline-block;
+}
+
+.collapsible-header[aria-expanded="true"] .collapsible-chevron {
+    transform: rotate(90deg);
+}
+
+.collapsible-body {
+    background: var(--bg-surface);
+}
+
+
+/* --------------------------------------------------------------------------
+   20d. Toggle Switch Label — settings page pause toggle
+   -------------------------------------------------------------------------- */
+
+.toggle-switch-label {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    cursor: pointer;
+}
+
+.toggle-switch-text {
+    font-size: 0.8rem;
+    color: var(--fg-secondary);
+    font-weight: 500;
+    min-width: 24px;
+}
+
+
+/* --------------------------------------------------------------------------
+   20e. Custom Duration Picker — unit dropdown + number input combo
+   -------------------------------------------------------------------------- */
+
+.poll-interval-control {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    flex-wrap: wrap;
+}
+
+.custom-duration-wrap {
+    display: flex;
+    gap: var(--sp-2);
+    align-items: center;
+}
+
+.custom-duration-unit {
+    min-width: 110px;
+}
+
+.custom-duration-value {
+    width: 80px;
+    text-align: center;
+    background-image: none !important;
+    padding-right: 12px !important;
+    -moz-appearance: textfield;
+}
+
+.custom-duration-value::-webkit-inner-spin-button,
+.custom-duration-value::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.custom-duration-value:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+
+/* --------------------------------------------------------------------------
+   20f. Setting Row Variants
+   -------------------------------------------------------------------------- */
+
+.setting-row-top {
+    align-items: flex-start;
+}
+
+.setting-control-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    align-items: flex-end;
+}
+
+
+/* --------------------------------------------------------------------------
    21. Utility Helpers
    -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
## Summary
- **Runtime-mutable settings:** Default policy, grace period, pause scanning, and container name filters — all persisted in BoltDB and applied without restart
- **Per-channel notification event filtering:** Toggle which event types (update available, started, complete, failed, rollback, state change) each notification channel receives
- **Settings page restructure:** 3-tab layout (General, Notifications, Appearance) with collapsible environment variables section
- **Dashboard pause banner:** Warning banner with resume button when scanning is paused
- **Custom duration UX:** Unit dropdown (seconds/minutes/hours) with progressive disclosure — value input stays disabled until unit is chosen

## Test plan
- [ ] Verify settings page loads with correct current values
- [ ] Change default policy, grace period, poll interval — confirm toast + persistence across refresh
- [ ] Toggle pause scanning — confirm banner appears on dashboard
- [ ] Add container filter patterns — confirm filtered containers are skipped on next scan
- [ ] Toggle event pills on notification channel — save and verify only selected events trigger notifications
- [ ] Select "Custom..." for grace period/poll interval — verify unit dropdown → value input → Apply flow
- [ ] Confirm existing custom values load correctly (unit + value pre-populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)