### PR TITLE
feat: Stack header status indicators

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -43,9 +43,12 @@ type containerView struct {
 
 // stackGroup groups containers by their Docker Compose project name.
 type stackGroup struct {
-	Name       string
-	Containers []containerView
-	HasPending bool // true if any container in the group has an update available
+	Name         string
+	Containers   []containerView
+	HasPending   bool // true if any container in the group has an update available
+	RunningCount int
+	StoppedCount int
+	PendingCount int
 }
 
 // handleDashboard renders the main container dashboard.
@@ -149,9 +152,14 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			Containers: stackMap[key],
 		}
 		for _, c := range group.Containers {
+			if c.State == "running" {
+				group.RunningCount++
+			} else {
+				group.StoppedCount++
+			}
 			if c.HasUpdate {
 				group.HasPending = true
-				break
+				group.PendingCount++
 			}
 		}
 		stacks = append(stacks, group)

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -98,8 +98,11 @@
                                     <div class="stack-header-inner">
                                         <span class="stack-chevron">&#9656;</span>
                                         <span class="stack-name">{{.Name}}</span>
-                                        <span class="badge badge-muted stack-count">{{len .Containers}}</span>
-                                        {{if .HasPending}}<span class="badge badge-warning">Updates Available</span>{{end}}
+                                        <span class="stack-counts">
+                                            <span class="stack-indicator stack-indicator-running">{{.RunningCount}}</span>
+                                            {{if .StoppedCount}}<span class="stack-indicator stack-indicator-stopped">{{.StoppedCount}}</span>{{end}}
+                                            {{if .PendingCount}}<span class="stack-indicator stack-indicator-pending">{{.PendingCount}}</span>{{end}}
+                                        </span>
                                     </div>
                                 </td>
                             </tr>

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -823,9 +823,56 @@ td:nth-child(6) {
     color: var(--fg-primary);
 }
 
-.stack-count {
-    font-size: 0.65rem;
-    padding: 1px 6px;
+.stack-counts {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-3);
+    margin-left: var(--sp-2);
+}
+
+.stack-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    font-family: var(--font-mono);
+}
+
+.stack-indicator::before {
+    content: "";
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+}
+
+.stack-indicator-running {
+    color: var(--success);
+}
+
+.stack-indicator-running::before {
+    background: var(--success);
+    box-shadow: 0 0 4px light-dark(rgba(34, 197, 94, 0.4), rgba(74, 222, 128, 0.4));
+}
+
+.stack-indicator-stopped {
+    color: var(--error);
+}
+
+.stack-indicator-stopped::before {
+    background: var(--error);
+    box-shadow: 0 0 4px light-dark(rgba(239, 68, 68, 0.3), rgba(248, 113, 113, 0.3));
+}
+
+.stack-indicator-pending {
+    color: var(--warning);
+}
+
+.stack-indicator-pending::before {
+    background: var(--warning);
+    box-shadow: 0 0 4px light-dark(rgba(245, 158, 11, 0.3), rgba(251, 191, 36, 0.3));
 }
 
 /* Pending stack highlight */


### PR DESCRIPTION
## Summary
- Replace single muted count badge on stack headers with three coloured dot+number indicators
- Green dot = running containers, red dot = stopped/offline, orange dot = pending updates
- Stopped and pending indicators only appear when count > 0
- Larger font (0.85rem mono) for better readability

## Test plan
- [ ] Verify stack headers show green dot with running count
- [ ] Stop a container — verify red dot appears with stopped count
- [ ] Queue an update — verify orange dot appears with pending count

🤖 Generated with [Claude Code](https://claude.com/claude-code)