### PR TITLE
fix: 8 bugs from Codex code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ All configuration is via environment variables. Settings marked with * can also 
 | `SENTINEL_WEB_ENABLED` | `true` | Enable web dashboard |
 | `SENTINEL_WEB_PORT` | `8080` | Web dashboard port |
 | `SENTINEL_DOCKER_SOCK` | `/var/run/docker.sock` | Docker socket path |
-| `SENTINEL_DOCKER_CONFIG` | `/root/.docker/config.json` | Docker config for private registry auth |
 | `SENTINEL_GOTIFY_URL` | | Gotify server URL (legacy — prefer web UI) |
 | `SENTINEL_GOTIFY_TOKEN` | | Gotify application token (legacy — prefer web UI) |
 | `SENTINEL_WEBHOOK_URL` | | Webhook URL for JSON POST (legacy — prefer web UI) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,20 +5,17 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 )
 
 // Config holds all Docker-Sentinel configuration from environment variables.
+// Mutable fields (PollInterval, GracePeriod, DefaultPolicy) are protected by
+// an RWMutex and must be accessed via getter/setter methods at runtime, since
+// the engine goroutine reads them while HTTP handlers may write them.
 type Config struct {
 	// Docker connection
 	DockerSock string
-
-	// Scanning
-	PollInterval time.Duration // how often to scan for updates
-	GracePeriod  time.Duration // wait after starting new container before health check
-
-	// Update policy
-	DefaultPolicy string // "auto", "manual", or "pinned"
 
 	// Storage
 	DBPath string
@@ -32,63 +29,86 @@ type Config struct {
 	WebhookURL     string
 	WebhookHeaders string // comma-separated "Key:Value" pairs
 
-	// Registry
-	DockerConfigPath string // path to docker config.json for private registry auth
-
 	// Web dashboard
 	WebPort    string
 	WebEnabled bool
+
+	// mu protects the mutable runtime fields below.
+	mu            sync.RWMutex
+	pollInterval  time.Duration // how often to scan for updates
+	gracePeriod   time.Duration // wait after starting new container before health check
+	defaultPolicy string        // "auto", "manual", or "pinned"
+}
+
+// NewTestConfig creates a Config with sensible defaults for testing.
+// Use the setter methods to override specific values.
+func NewTestConfig() *Config {
+	return &Config{
+		pollInterval:  6 * time.Hour,
+		gracePeriod:   30 * time.Second,
+		defaultPolicy: "manual",
+	}
 }
 
 // Load reads all configuration from environment variables with defaults.
 func Load() *Config {
 	return &Config{
-		DockerSock:       envStr("SENTINEL_DOCKER_SOCK", "/var/run/docker.sock"),
-		PollInterval:     envDuration("SENTINEL_POLL_INTERVAL", 6*time.Hour),
-		GracePeriod:      envDuration("SENTINEL_GRACE_PERIOD", 30*time.Second),
-		DefaultPolicy:    envStr("SENTINEL_DEFAULT_POLICY", "manual"),
-		DBPath:           envStr("SENTINEL_DB_PATH", "/data/sentinel.db"),
-		LogJSON:          envBool("SENTINEL_LOG_JSON", true),
-		GotifyURL:        envStr("SENTINEL_GOTIFY_URL", ""),
-		GotifyToken:      envStr("SENTINEL_GOTIFY_TOKEN", ""),
-		WebhookURL:       envStr("SENTINEL_WEBHOOK_URL", ""),
-		WebhookHeaders:   envStr("SENTINEL_WEBHOOK_HEADERS", ""),
-		DockerConfigPath: envStr("SENTINEL_DOCKER_CONFIG", "/root/.docker/config.json"),
-		WebPort:          envStr("SENTINEL_WEB_PORT", "8080"),
-		WebEnabled:       envBool("SENTINEL_WEB_ENABLED", true),
+		DockerSock:     envStr("SENTINEL_DOCKER_SOCK", "/var/run/docker.sock"),
+		pollInterval:   envDuration("SENTINEL_POLL_INTERVAL", 6*time.Hour),
+		gracePeriod:    envDuration("SENTINEL_GRACE_PERIOD", 30*time.Second),
+		defaultPolicy:  envStr("SENTINEL_DEFAULT_POLICY", "manual"),
+		DBPath:         envStr("SENTINEL_DB_PATH", "/data/sentinel.db"),
+		LogJSON:        envBool("SENTINEL_LOG_JSON", true),
+		GotifyURL:      envStr("SENTINEL_GOTIFY_URL", ""),
+		GotifyToken:    envStr("SENTINEL_GOTIFY_TOKEN", ""),
+		WebhookURL:     envStr("SENTINEL_WEBHOOK_URL", ""),
+		WebhookHeaders: envStr("SENTINEL_WEBHOOK_HEADERS", ""),
+		WebPort:        envStr("SENTINEL_WEB_PORT", "8080"),
+		WebEnabled:     envBool("SENTINEL_WEB_ENABLED", true),
 	}
 }
 
 // Validate checks configuration for invalid values.
 func (c *Config) Validate() error {
+	c.mu.RLock()
+	pi := c.pollInterval
+	gp := c.gracePeriod
+	dp := c.defaultPolicy
+	c.mu.RUnlock()
+
 	var errs []error
-	if c.PollInterval <= 0 {
-		errs = append(errs, fmt.Errorf("SENTINEL_POLL_INTERVAL must be > 0, got %s", c.PollInterval))
+	if pi <= 0 {
+		errs = append(errs, fmt.Errorf("SENTINEL_POLL_INTERVAL must be > 0, got %s", pi))
 	}
-	if c.GracePeriod < 0 {
-		errs = append(errs, fmt.Errorf("SENTINEL_GRACE_PERIOD must be >= 0, got %s", c.GracePeriod))
+	if gp < 0 {
+		errs = append(errs, fmt.Errorf("SENTINEL_GRACE_PERIOD must be >= 0, got %s", gp))
 	}
-	switch c.DefaultPolicy {
+	switch dp {
 	case "auto", "manual", "pinned":
 		// valid
 	default:
-		errs = append(errs, fmt.Errorf("SENTINEL_DEFAULT_POLICY must be auto, manual, or pinned, got %q", c.DefaultPolicy))
+		errs = append(errs, fmt.Errorf("SENTINEL_DEFAULT_POLICY must be auto, manual, or pinned, got %q", dp))
 	}
 	return errors.Join(errs...)
 }
 
 // Values returns all configuration as a string map for display.
 func (c *Config) Values() map[string]string {
+	c.mu.RLock()
+	pi := c.pollInterval
+	gp := c.gracePeriod
+	dp := c.defaultPolicy
+	c.mu.RUnlock()
+
 	return map[string]string{
 		"SENTINEL_DOCKER_SOCK":    c.DockerSock,
-		"SENTINEL_POLL_INTERVAL":  c.PollInterval.String(),
-		"SENTINEL_GRACE_PERIOD":   c.GracePeriod.String(),
-		"SENTINEL_DEFAULT_POLICY": c.DefaultPolicy,
+		"SENTINEL_POLL_INTERVAL":  pi.String(),
+		"SENTINEL_GRACE_PERIOD":   gp.String(),
+		"SENTINEL_DEFAULT_POLICY": dp,
 		"SENTINEL_DB_PATH":        c.DBPath,
 		"SENTINEL_LOG_JSON":       fmt.Sprintf("%t", c.LogJSON),
 		"SENTINEL_GOTIFY_URL":     c.GotifyURL,
 		"SENTINEL_WEBHOOK_URL":    c.WebhookURL,
-		"SENTINEL_DOCKER_CONFIG":  c.DockerConfigPath,
 		"SENTINEL_WEB_PORT":       c.WebPort,
 		"SENTINEL_WEB_ENABLED":    fmt.Sprintf("%t", c.WebEnabled),
 	}
@@ -137,7 +157,44 @@ func envDuration(key string, def time.Duration) time.Duration {
 	return d
 }
 
-// SetPollInterval updates the poll interval at runtime.
+// PollInterval returns the current poll interval (thread-safe).
+func (c *Config) PollInterval() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.pollInterval
+}
+
+// SetPollInterval updates the poll interval at runtime (thread-safe).
 func (c *Config) SetPollInterval(d time.Duration) {
-	c.PollInterval = d
+	c.mu.Lock()
+	c.pollInterval = d
+	c.mu.Unlock()
+}
+
+// GracePeriod returns the current grace period (thread-safe).
+func (c *Config) GracePeriod() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gracePeriod
+}
+
+// SetGracePeriod updates the grace period at runtime (thread-safe).
+func (c *Config) SetGracePeriod(d time.Duration) {
+	c.mu.Lock()
+	c.gracePeriod = d
+	c.mu.Unlock()
+}
+
+// DefaultPolicy returns the current default policy (thread-safe).
+func (c *Config) DefaultPolicy() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.defaultPolicy
+}
+
+// SetDefaultPolicy updates the default policy at runtime (thread-safe).
+func (c *Config) SetDefaultPolicy(s string) {
+	c.mu.Lock()
+	c.defaultPolicy = s
+	c.mu.Unlock()
 }

--- a/internal/engine/queue_test.go
+++ b/internal/engine/queue_test.go
@@ -21,7 +21,7 @@ func testStore(t *testing.T) *store.Store {
 
 func TestQueueAddAndList(t *testing.T) {
 	s := testStore(t)
-	q := NewQueue(s, nil)
+	q := NewQueue(s, nil, nil)
 
 	q.Add(PendingUpdate{ContainerName: "nginx", ContainerID: "aaa"})
 	q.Add(PendingUpdate{ContainerName: "redis", ContainerID: "bbb"})
@@ -38,7 +38,7 @@ func TestQueueAddAndList(t *testing.T) {
 
 func TestQueueGetAndRemove(t *testing.T) {
 	s := testStore(t)
-	q := NewQueue(s, nil)
+	q := NewQueue(s, nil, nil)
 
 	q.Add(PendingUpdate{ContainerName: "nginx", ContainerID: "aaa", DetectedAt: time.Now()})
 
@@ -62,7 +62,7 @@ func TestQueueGetAndRemove(t *testing.T) {
 
 func TestQueueReplaceExisting(t *testing.T) {
 	s := testStore(t)
-	q := NewQueue(s, nil)
+	q := NewQueue(s, nil, nil)
 
 	q.Add(PendingUpdate{ContainerName: "nginx", RemoteDigest: "sha256:old"})
 	q.Add(PendingUpdate{ContainerName: "nginx", RemoteDigest: "sha256:new"})
@@ -80,12 +80,12 @@ func TestQueuePersistence(t *testing.T) {
 	s := testStore(t)
 
 	// Add items in one queue instance.
-	q1 := NewQueue(s, nil)
+	q1 := NewQueue(s, nil, nil)
 	q1.Add(PendingUpdate{ContainerName: "nginx", ContainerID: "aaa"})
 	q1.Add(PendingUpdate{ContainerName: "redis", ContainerID: "bbb"})
 
 	// Create a new queue from the same store — should restore.
-	q2 := NewQueue(s, nil)
+	q2 := NewQueue(s, nil, nil)
 	if q2.Len() != 2 {
 		t.Fatalf("restored queue Len() = %d, want 2", q2.Len())
 	}

--- a/internal/engine/rollback.go
+++ b/internal/engine/rollback.go
@@ -18,6 +18,10 @@ func rollback(ctx context.Context, d docker.API, name string, snapshotData []byt
 		return fmt.Errorf("unmarshal snapshot: %w", err)
 	}
 
+	if inspect.Config == nil {
+		return fmt.Errorf("inspect %s: container config is nil", name)
+	}
+
 	log.Info("rolling back container", "name", name, "image", inspect.Config.Image)
 
 	cfg := cloneConfig(inspect.Config)

--- a/internal/engine/scheduler.go
+++ b/internal/engine/scheduler.go
@@ -54,7 +54,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	for {
 		select {
-		case <-s.clock.After(s.cfg.PollInterval):
+		case <-s.clock.After(s.cfg.PollInterval()):
 			if s.isPaused() {
 				s.log.Info("scheduler is paused, skipping scheduled scan")
 				continue
@@ -63,7 +63,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			result := s.updater.Scan(ctx)
 			s.logResult(result)
 		case <-s.resetCh:
-			s.log.Info("poll interval changed, resetting timer", "interval", s.cfg.PollInterval)
+			s.log.Info("poll interval changed, resetting timer", "interval", s.cfg.PollInterval())
 			// Timer resets on next loop iteration
 		case <-ctx.Done():
 			s.log.Info("scheduler stopped")

--- a/internal/engine/scheduler_test.go
+++ b/internal/engine/scheduler_test.go
@@ -14,15 +14,14 @@ import (
 func TestSchedulerRunsInitialScan(t *testing.T) {
 	mock := newMockDocker()
 	s := testStore(t)
-	q := NewQueue(s, nil)
+	q := NewQueue(s, nil, nil)
 	log := logging.New(false)
 	clk := newMockClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	checker := registry.NewChecker(mock, log)
-	cfg := &config.Config{
-		DefaultPolicy: "manual",
-		GracePeriod:   1 * time.Second,
-		PollInterval:  1 * time.Hour,
-	}
+	cfg := config.NewTestConfig()
+	cfg.SetDefaultPolicy("manual")
+	cfg.SetGracePeriod(1 * time.Second)
+	cfg.SetPollInterval(1 * time.Hour)
 	notifier := notify.NewMulti(log)
 	u := NewUpdater(mock, checker, s, q, cfg, log, clk, notifier, nil)
 	sched := NewScheduler(u, cfg, log, clk)

--- a/internal/engine/selfupdate.go
+++ b/internal/engine/selfupdate.go
@@ -56,6 +56,10 @@ func (su *SelfUpdater) Update(ctx context.Context) error {
 		return fmt.Errorf("inspect self: %w", err)
 	}
 
+	if inspect.Config == nil {
+		return fmt.Errorf("inspect %s: container config is nil", selfName)
+	}
+
 	imageRef := inspect.Config.Image
 	su.log.Info("self-update initiated", "name", selfName, "image", imageRef)
 

--- a/internal/notify/filtered_test.go
+++ b/internal/notify/filtered_test.go
@@ -101,6 +101,93 @@ func TestBuildFilteredNotifierWithEvents(t *testing.T) {
 	}
 }
 
+func TestCanonicaliseEventKey(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"update_complete", "update_succeeded"},
+		{"rollback", "rollback_succeeded"},
+		{"state_change", "container_state"},
+		{"update_available", "update_available"},
+		{"update_started", "update_started"},
+		{"update_succeeded", "update_succeeded"},
+		{"update_failed", "update_failed"},
+		{"rollback_succeeded", "rollback_succeeded"},
+		{"rollback_failed", "rollback_failed"},
+		{"container_state", "container_state"},
+		{"unknown_key", "unknown_key"},
+	}
+	for _, tt := range tests {
+		got := canonicaliseEventKey(tt.input)
+		if got != tt.want {
+			t.Errorf("canonicaliseEventKey(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFilteredNotifierLegacyKeysMatchCurrentEvents(t *testing.T) {
+	inner := &stubNotifier{name: "test"}
+
+	// Simulate a channel saved with old legacy keys.
+	f := newFilteredNotifier(inner, []string{"update_complete", "rollback", "state_change"})
+
+	// "update_complete" should match EventUpdateSucceeded.
+	if err := f.Send(context.Background(), testEvent(EventUpdateSucceeded)); err != nil {
+		t.Fatalf("Send(EventUpdateSucceeded) error = %v", err)
+	}
+	if len(inner.sent) != 1 {
+		t.Fatalf("EventUpdateSucceeded: got %d events, want 1", len(inner.sent))
+	}
+
+	// "rollback" should match EventRollbackOK (rollback_succeeded).
+	if err := f.Send(context.Background(), testEvent(EventRollbackOK)); err != nil {
+		t.Fatalf("Send(EventRollbackOK) error = %v", err)
+	}
+	if len(inner.sent) != 2 {
+		t.Fatalf("EventRollbackOK: got %d events, want 2", len(inner.sent))
+	}
+
+	// "state_change" should match EventContainerState.
+	if err := f.Send(context.Background(), testEvent(EventContainerState)); err != nil {
+		t.Fatalf("Send(EventContainerState) error = %v", err)
+	}
+	if len(inner.sent) != 3 {
+		t.Fatalf("EventContainerState: got %d events, want 3", len(inner.sent))
+	}
+
+	// Events NOT in the legacy set should still be blocked.
+	if err := f.Send(context.Background(), testEvent(EventUpdateAvailable)); err != nil {
+		t.Fatalf("Send(EventUpdateAvailable) error = %v", err)
+	}
+	if len(inner.sent) != 3 {
+		t.Fatalf("EventUpdateAvailable should be blocked: got %d events, want 3", len(inner.sent))
+	}
+}
+
+func TestFilteredNotifierMixedLegacyAndCurrentKeys(t *testing.T) {
+	inner := &stubNotifier{name: "test"}
+
+	// Mix of legacy and current keys.
+	f := newFilteredNotifier(inner, []string{"update_complete", "update_available", "rollback_failed"})
+
+	// "update_complete" (legacy) -> update_succeeded
+	if err := f.Send(context.Background(), testEvent(EventUpdateSucceeded)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	// "update_available" (current, unchanged)
+	if err := f.Send(context.Background(), testEvent(EventUpdateAvailable)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	// "rollback_failed" (current, unchanged)
+	if err := f.Send(context.Background(), testEvent(EventRollbackFailed)); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if len(inner.sent) != 3 {
+		t.Fatalf("got %d events, want 3", len(inner.sent))
+	}
+}
+
 func TestBuildFilteredNotifierWithoutEvents(t *testing.T) {
 	settings := []byte(`{"url":"http://example.com","token":"tok"}`)
 	ch := Channel{

--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -2,12 +2,9 @@ package registry
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
-	"strings"
 	"time"
 )
 
@@ -18,22 +15,6 @@ var httpClient = &http.Client{Timeout: 10 * time.Second}
 // TokenResponse holds the bearer token returned by a registry auth endpoint.
 type TokenResponse struct {
 	Token string `json:"token"`
-}
-
-// AuthEntry holds decoded credentials from a Docker config file.
-type AuthEntry struct {
-	Username string
-	Password string
-}
-
-// dockerConfig represents the top-level structure of ~/.docker/config.json.
-type dockerConfig struct {
-	Auths map[string]dockerConfigAuth `json:"auths"`
-}
-
-// dockerConfigAuth holds the base64-encoded "auth" field from config.json.
-type dockerConfigAuth struct {
-	Auth string `json:"auth"`
 }
 
 // FetchAnonymousToken retrieves an anonymous bearer token from Docker Hub's
@@ -65,43 +46,4 @@ func FetchAnonymousToken(ctx context.Context, repo string) (string, error) {
 	}
 
 	return tok.Token, nil
-}
-
-// ReadDockerConfig parses a Docker config.json file and returns a map of
-// registry hostname to decoded credentials. Each "auth" value is expected
-// to be base64-encoded "username:password".
-func ReadDockerConfig(path string) (map[string]AuthEntry, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read docker config: %w", err)
-	}
-
-	var cfg dockerConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse docker config: %w", err)
-	}
-
-	result := make(map[string]AuthEntry, len(cfg.Auths))
-	for registry, auth := range cfg.Auths {
-		if auth.Auth == "" {
-			continue
-		}
-
-		decoded, err := base64.StdEncoding.DecodeString(auth.Auth)
-		if err != nil {
-			continue
-		}
-
-		parts := strings.SplitN(string(decoded), ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		result[registry] = AuthEntry{
-			Username: parts[0],
-			Password: parts[1],
-		}
-	}
-
-	return result, nil
 }

--- a/internal/registry/auth_test.go
+++ b/internal/registry/auth_test.go
@@ -5,84 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 )
-
-func TestReadDockerConfig(t *testing.T) {
-	// Create a temp config.json with base64("user:pass") = "dXNlcjpwYXNz"
-	cfg := map[string]any{
-		"auths": map[string]any{
-			"https://index.docker.io/v1/": map[string]string{
-				"auth": "dXNlcjpwYXNz",
-			},
-			"ghcr.io": map[string]string{
-				"auth": "Z2h1c2VyOmdodG9rZW4=", // "ghuser:ghtoken"
-			},
-			"empty.io": map[string]string{
-				"auth": "",
-			},
-		},
-	}
-
-	data, err := json.Marshal(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	path := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := ReadDockerConfig(path)
-	if err != nil {
-		t.Fatalf("ReadDockerConfig: %v", err)
-	}
-
-	// Docker Hub entry.
-	entry, ok := result["https://index.docker.io/v1/"]
-	if !ok {
-		t.Fatal("missing Docker Hub entry")
-	}
-	if entry.Username != "user" || entry.Password != "pass" {
-		t.Errorf("Docker Hub entry = %+v, want user:pass", entry)
-	}
-
-	// GHCR entry.
-	entry, ok = result["ghcr.io"]
-	if !ok {
-		t.Fatal("missing GHCR entry")
-	}
-	if entry.Username != "ghuser" || entry.Password != "ghtoken" {
-		t.Errorf("GHCR entry = %+v, want ghuser:ghtoken", entry)
-	}
-
-	// Empty auth should be skipped.
-	if _, ok := result["empty.io"]; ok {
-		t.Error("empty.io should be skipped (empty auth)")
-	}
-}
-
-func TestReadDockerConfigMissing(t *testing.T) {
-	_, err := ReadDockerConfig("/nonexistent/config.json")
-	if err == nil {
-		t.Error("expected error for missing file")
-	}
-}
-
-func TestReadDockerConfigInvalidJSON(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := ReadDockerConfig(path)
-	if err == nil {
-		t.Error("expected error for invalid JSON")
-	}
-}
 
 func TestFetchAnonymousToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/store/bolt.go
+++ b/internal/store/bolt.go
@@ -30,7 +30,7 @@ type UpdateRecord struct {
 	OldDigest     string        `json:"old_digest"`
 	NewImage      string        `json:"new_image"`
 	NewDigest     string        `json:"new_digest"`
-	Outcome       string        `json:"outcome"` // "success" or "rollback"
+	Outcome       string        `json:"outcome"` // "success", "rollback", "failed", or "finalise_warning"
 	Duration      time.Duration `json:"duration"`
 	Error         string        `json:"error,omitempty"`
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -24,6 +24,7 @@ type Dependencies struct {
 	Docker             ContainerLister
 	Updater            ContainerUpdater
 	Config             ConfigReader
+	ConfigWriter       ConfigWriter
 	EventBus           *events.Bus
 	Snapshots          SnapshotStore
 	Rollback           ContainerRollback
@@ -189,6 +190,7 @@ type ContainerInspect struct {
 // ContainerUpdater triggers container updates.
 type ContainerUpdater interface {
 	UpdateContainer(ctx context.Context, id, name string) error
+	IsUpdating(name string) bool
 }
 
 // ContainerRestarter restarts a container by ID.
@@ -209,6 +211,12 @@ type ContainerStarter interface {
 // ConfigReader provides settings for display.
 type ConfigReader interface {
 	Values() map[string]string
+}
+
+// ConfigWriter updates mutable runtime settings in memory.
+type ConfigWriter interface {
+	SetDefaultPolicy(s string)
+	SetGracePeriod(d time.Duration)
 }
 
 // Server is the web dashboard HTTP server.


### PR DESCRIPTION
## Summary

Full codebase review by Codex CLI (GPT-5.3 xhigh) found 13 issues. After verification against source code, 8 needed fixing plus 2 issues found during post-fix Codex review.

**Fixes:**
- **Notification event filter mismatch** — frontend used wrong event keys (`update_complete` vs `update_succeeded`, etc.). Added legacy key canonicalization for existing BoltDB configs.
- **Silent container downtime** — `finaliseContainer` errors were ignored, recording success even when container was down. Now stage-aware: rollback on destructive failures, never record false success.
- **Per-container update lock** — concurrent updates on the same container could race. Added `sync.Map` of per-container mutexes with re-enqueue on busy for approved items.
- **Runtime settings not applied** — `DefaultPolicy` and `GracePeriod` changes via UI required restart. Added `sync.RWMutex` with thread-safe getters/setters.
- **Nil-pointer guards** — `inspect.Config` dereferences in updater, rollback, and selfupdate without nil checks.
- **Silent persistence errors** — `_ = store.Method()` dropped errors. Now logged at warn level. Added logger to Queue struct.
- **Dead code removal** — `SENTINEL_DOCKER_CONFIG` env var loaded but never used. Removed config, structs, and tests.
- **Bulk policy confirm flow** — "Select all → change policy" was preview-only (never sent `confirm: true`). Added two-step preview-then-apply UI flow.

**Post-review fixes:**
- Removed racy `IsUpdating` pre-check in `apiApprove` — re-enqueue on busy instead of silently dropping
- Evict stale mutex entries from `sync.Map` after unlock

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` passes
- [x] `go test -race ./internal/config/ ./internal/engine/` passes
- [x] Gitea CI run #72 passed (build + lint + test)
- [ ] Manual test: bulk policy change in Manage mode
- [ ] Manual test: concurrent update requests return 409
- [ ] Manual test: notification event filters match correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)