### PR TITLE
feat: add authentication and authorisation (v1.7.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,5 +26,7 @@ require (
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -53,10 +53,16 @@ go.opentelemetry.io/otel/sdk/metric v1.35.0 h1:1RriWBmCKgkeHEhM7a2uMjMUfP7MsOF5J
 go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
 go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"time"
+)
+
+// Permission represents a granular capability.
+type Permission string
+
+const (
+	PermContainersView     Permission = "containers.view"
+	PermContainersUpdate   Permission = "containers.update"
+	PermContainersApprove  Permission = "containers.approve"
+	PermContainersRollback Permission = "containers.rollback"
+	PermContainersManage   Permission = "containers.manage"
+	PermSettingsView       Permission = "settings.view"
+	PermSettingsModify     Permission = "settings.modify"
+	PermUsersManage        Permission = "users.manage"
+	PermLogsView           Permission = "logs.view"
+	PermHistoryView        Permission = "history.view"
+)
+
+// AllPermissions returns every defined permission.
+func AllPermissions() []Permission {
+	return []Permission{
+		PermContainersView, PermContainersUpdate, PermContainersApprove,
+		PermContainersRollback, PermContainersManage, PermSettingsView,
+		PermSettingsModify, PermUsersManage, PermLogsView, PermHistoryView,
+	}
+}
+
+// User represents an authenticated user.
+type User struct {
+	ID           string    `json:"id"`
+	Username     string    `json:"username"`
+	PasswordHash string    `json:"password_hash"`
+	RoleID       string    `json:"role_id"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Locked       bool      `json:"locked"`        // locked after too many failed logins
+	LockedUntil  time.Time `json:"locked_until"`  // unlock time
+	FailedLogins int       `json:"failed_logins"` // consecutive failures
+}
+
+// Session represents an active login session.
+type Session struct {
+	Token     string    `json:"token"`      // 64-char hex token (also the bucket key)
+	UserID    string    `json:"user_id"`
+	IP        string    `json:"ip"`
+	UserAgent string    `json:"user_agent"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// Role defines a named set of permissions.
+type Role struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Permissions []Permission `json:"permissions"`
+	BuiltIn     bool         `json:"built_in"`
+}
+
+// APIToken represents a bearer token for programmatic API access.
+type APIToken struct {
+	ID          string       `json:"id"`           // 16-char hex ID
+	Name        string       `json:"name"`         // user-friendly label
+	TokenHash   string       `json:"token_hash"`   // SHA-256 hex of the full token
+	UserID      string       `json:"user_id"`
+	Permissions []Permission `json:"permissions"`   // nil = inherit from user role
+	CreatedAt   time.Time    `json:"created_at"`
+	ExpiresAt   time.Time    `json:"expires_at"`    // zero = no expiry
+	LastUsedAt  time.Time    `json:"last_used_at"`
+}
+
+// RequestContext is extracted from the request by middleware and placed in context.
+type RequestContext struct {
+	User        *User
+	Session     *Session
+	APIToken    *APIToken
+	Permissions []Permission
+	AuthEnabled bool
+}
+
+// HasPermission checks if the request context includes a specific permission.
+func (rc *RequestContext) HasPermission(p Permission) bool {
+	for _, perm := range rc.Permissions {
+		if perm == p {
+			return true
+		}
+	}
+	return false
+}
+
+// contextKey is an unexported type for context keys.
+type contextKey struct{}
+
+// ContextKey is the key used to store RequestContext in context.Context.
+var ContextKey = contextKey{}

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+const (
+	CSRFCookieName = "sentinel_csrf"
+	CSRFHeaderName = "X-CSRF-Token"
+	csrfTokenBytes = 32
+)
+
+// GenerateCSRFToken creates a cryptographically random CSRF token.
+func GenerateCSRFToken() (string, error) {
+	b := make([]byte, csrfTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// SetCSRFCookie sets the CSRF double-submit cookie (readable by JS).
+func SetCSRFCookie(w http.ResponseWriter, token string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CSRFCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: false, // JS must read this to send in header
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secure,
+	})
+}
+
+// ValidateCSRF checks that the CSRF header matches the CSRF cookie (double-submit pattern).
+func ValidateCSRF(r *http.Request) bool {
+	cookie, err := r.Cookie(CSRFCookieName)
+	if err != nil || cookie.Value == "" {
+		return false
+	}
+	header := r.Header.Get(CSRFHeaderName)
+	if header == "" {
+		// Also check form value as fallback for HTML form submissions.
+		header = r.FormValue("csrf_token")
+	}
+	return header != "" && header == cookie.Value
+}

--- a/internal/auth/csrf_test.go
+++ b/internal/auth/csrf_test.go
@@ -1,0 +1,140 @@
+package auth
+
+import (
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGenerateCSRFToken(t *testing.T) {
+	t.Run("returns 64-char hex string", func(t *testing.T) {
+		token, err := GenerateCSRFToken()
+		if err != nil {
+			t.Fatalf("GenerateCSRFToken failed: %v", err)
+		}
+		if len(token) != 64 {
+			t.Errorf("expected 64 chars, got %d", len(token))
+		}
+		if _, err := hex.DecodeString(token); err != nil {
+			t.Errorf("token is not valid hex: %v", err)
+		}
+	})
+
+	t.Run("tokens are unique", func(t *testing.T) {
+		t1, _ := GenerateCSRFToken()
+		t2, _ := GenerateCSRFToken()
+		if t1 == t2 {
+			t.Error("two generated CSRF tokens should not be identical")
+		}
+	})
+}
+
+func TestSetCSRFCookie(t *testing.T) {
+	t.Run("HttpOnly is false", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		SetCSRFCookie(w, "csrf-token-value", false)
+
+		resp := w.Result()
+		cookies := resp.Cookies()
+		if len(cookies) != 1 {
+			t.Fatalf("expected 1 cookie, got %d", len(cookies))
+		}
+		c := cookies[0]
+		if c.Name != CSRFCookieName {
+			t.Errorf("expected cookie name %q, got %q", CSRFCookieName, c.Name)
+		}
+		if c.Value != "csrf-token-value" {
+			t.Errorf("expected cookie value %q, got %q", "csrf-token-value", c.Value)
+		}
+		if c.HttpOnly {
+			t.Error("CSRF cookie must NOT be HttpOnly (JS needs to read it)")
+		}
+		if c.Path != "/" {
+			t.Errorf("expected path '/', got %q", c.Path)
+		}
+		if c.SameSite != http.SameSiteLaxMode {
+			t.Errorf("expected SameSiteLaxMode, got %v", c.SameSite)
+		}
+	})
+
+	t.Run("secure flag propagated", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		SetCSRFCookie(w, "token", true)
+		resp := w.Result()
+		c := resp.Cookies()[0]
+		if !c.Secure {
+			t.Error("expected Secure to be true")
+		}
+	})
+}
+
+func TestValidateCSRF(t *testing.T) {
+	t.Run("matching header and cookie", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  CSRFCookieName,
+			Value: "matching-token",
+		})
+		req.Header.Set(CSRFHeaderName, "matching-token")
+		if !ValidateCSRF(req) {
+			t.Error("expected validation to pass with matching header and cookie")
+		}
+	})
+
+	t.Run("mismatched header and cookie", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  CSRFCookieName,
+			Value: "cookie-token",
+		})
+		req.Header.Set(CSRFHeaderName, "different-token")
+		if ValidateCSRF(req) {
+			t.Error("expected validation to fail with mismatched tokens")
+		}
+	})
+
+	t.Run("missing cookie", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", nil)
+		req.Header.Set(CSRFHeaderName, "some-token")
+		if ValidateCSRF(req) {
+			t.Error("expected validation to fail with missing cookie")
+		}
+	})
+
+	t.Run("missing header", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  CSRFCookieName,
+			Value: "cookie-token",
+		})
+		// No header set, no form value.
+		if ValidateCSRF(req) {
+			t.Error("expected validation to fail with missing header")
+		}
+	})
+
+	t.Run("empty cookie value", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  CSRFCookieName,
+			Value: "",
+		})
+		req.Header.Set(CSRFHeaderName, "")
+		if ValidateCSRF(req) {
+			t.Error("expected validation to fail with empty cookie value")
+		}
+	})
+
+	t.Run("form value fallback", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/submit?csrf_token=form-token", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  CSRFCookieName,
+			Value: "form-token",
+		})
+		// No header — should fall back to form value.
+		if !ValidateCSRF(req) {
+			t.Error("expected validation to pass with matching form value fallback")
+		}
+	})
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,152 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// AuthMiddleware checks authentication via session cookie or API bearer token.
+// If auth is disabled, injects a synthetic admin context.
+// Unauthenticated browser requests are redirected to /login.
+// Unauthenticated API requests get 401.
+func AuthMiddleware(svc *Service) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check if auth is enabled.
+			if !svc.AuthEnabled() {
+				// Auth disabled — inject synthetic admin context.
+				ctx := context.WithValue(r.Context(), ContextKey, &RequestContext{
+					User:        &User{ID: "system", Username: "admin"},
+					Permissions: AllPermissions(),
+					AuthEnabled: false,
+				})
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			var rc *RequestContext
+
+			// Try API bearer token first.
+			if bearer := ExtractBearerToken(r.Header.Get("Authorization")); bearer != "" {
+				rc = svc.ValidateBearerToken(r.Context(), bearer)
+				if rc != nil {
+					rc.AuthEnabled = true
+					ctx := context.WithValue(r.Context(), ContextKey, rc)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+				// Invalid bearer token.
+				http.Error(w, `{"error":"invalid or expired token"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Try session cookie.
+			if token := GetSessionToken(r); token != "" {
+				rc = svc.ValidateSession(r.Context(), token)
+				if rc != nil {
+					rc.AuthEnabled = true
+					// Ensure CSRF cookie is set for browser sessions.
+					ensureCSRFCookie(w, r, svc.CookieSecure)
+					ctx := context.WithValue(r.Context(), ContextKey, rc)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+				// Invalid/expired session — clear the stale cookie.
+				ClearSessionCookie(w, svc.CookieSecure)
+			}
+
+			// Not authenticated.
+			if isAPIRequest(r) {
+				http.Error(w, `{"error":"authentication required"}`, http.StatusUnauthorized)
+			} else {
+				http.Redirect(w, r, "/login", http.StatusSeeOther)
+			}
+		})
+	}
+}
+
+// CSRFMiddleware validates CSRF tokens on state-changing requests (POST/PUT/DELETE/PATCH).
+// Only applies to cookie-authenticated sessions — API bearer tokens are exempt.
+func CSRFMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Safe methods don't need CSRF validation.
+		if r.Method == "GET" || r.Method == "HEAD" || r.Method == "OPTIONS" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// API bearer tokens are exempt from CSRF (they're not cookie-based).
+		if ExtractBearerToken(r.Header.Get("Authorization")) != "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Auth disabled — skip CSRF.
+		rc := GetRequestContext(r.Context())
+		if rc != nil && !rc.AuthEnabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Validate CSRF double-submit.
+		if !ValidateCSRF(r) {
+			if isAPIRequest(r) {
+				http.Error(w, `{"error":"CSRF validation failed"}`, http.StatusForbidden)
+			} else {
+				http.Error(w, "CSRF validation failed", http.StatusForbidden)
+			}
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// RequirePermission returns middleware that checks for a specific permission.
+func RequirePermission(perm Permission) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rc := GetRequestContext(r.Context())
+			if rc == nil {
+				http.Error(w, `{"error":"authentication required"}`, http.StatusUnauthorized)
+				return
+			}
+			if !rc.HasPermission(perm) {
+				if isAPIRequest(r) {
+					http.Error(w, `{"error":"insufficient permissions"}`, http.StatusForbidden)
+				} else {
+					http.Error(w, "You don't have permission to access this page.", http.StatusForbidden)
+				}
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// GetRequestContext extracts the RequestContext from the request context.
+func GetRequestContext(ctx context.Context) *RequestContext {
+	rc, _ := ctx.Value(ContextKey).(*RequestContext)
+	return rc
+}
+
+// isAPIRequest checks if the request is an API call (JSON) vs browser navigation.
+func isAPIRequest(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	if strings.Contains(accept, "application/json") {
+		return true
+	}
+	return strings.HasPrefix(r.URL.Path, "/api/")
+}
+
+// ensureCSRFCookie sets a CSRF cookie if one doesn't already exist.
+func ensureCSRFCookie(w http.ResponseWriter, r *http.Request, secure bool) {
+	if _, err := r.Cookie(CSRFCookieName); err != nil {
+		token, err := GenerateCSRFToken()
+		if err != nil {
+			return
+		}
+		SetCSRFCookie(w, token, secure)
+	}
+}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,548 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGetRequestContext(t *testing.T) {
+	t.Run("returns nil from empty context", func(t *testing.T) {
+		ctx := context.Background()
+		rc := GetRequestContext(ctx)
+		if rc != nil {
+			t.Errorf("expected nil, got %v", rc)
+		}
+	})
+
+	t.Run("returns RequestContext when set", func(t *testing.T) {
+		rc := &RequestContext{
+			User:        &User{ID: "u1", Username: "testuser"},
+			Permissions: []Permission{PermContainersView},
+		}
+		ctx := context.WithValue(context.Background(), ContextKey, rc)
+		got := GetRequestContext(ctx)
+		if got == nil {
+			t.Fatal("expected non-nil RequestContext")
+		}
+		if got.User.ID != "u1" {
+			t.Errorf("expected user ID %q, got %q", "u1", got.User.ID)
+		}
+	})
+
+	t.Run("returns nil for wrong type in context", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), ContextKey, "not a RequestContext")
+		rc := GetRequestContext(ctx)
+		if rc != nil {
+			t.Errorf("expected nil for wrong type, got %v", rc)
+		}
+	})
+}
+
+func TestIsAPIRequest(t *testing.T) {
+	t.Run("api path prefix", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/containers", nil)
+		if !isAPIRequest(req) {
+			t.Error("expected /api/ path to be detected as API request")
+		}
+	})
+
+	t.Run("non-api path", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		if isAPIRequest(req) {
+			t.Error("expected /dashboard to not be detected as API request")
+		}
+	})
+
+	t.Run("Accept application/json header", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		req.Header.Set("Accept", "application/json")
+		if !isAPIRequest(req) {
+			t.Error("expected Accept: application/json to be detected as API request")
+		}
+	})
+
+	t.Run("Accept html header on non-api path", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		req.Header.Set("Accept", "text/html")
+		if isAPIRequest(req) {
+			t.Error("expected text/html Accept header to not be an API request")
+		}
+	})
+
+	t.Run("api path nested", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/users", nil)
+		if !isAPIRequest(req) {
+			t.Error("expected /api/v1/users to be detected as API request")
+		}
+	})
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	t.Run("auth disabled injects synthetic admin context", func(t *testing.T) {
+		svc := newTestService(false)
+
+		var capturedRC *RequestContext
+		handler := AuthMiddleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedRC = GetRequestContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		if capturedRC == nil {
+			t.Fatal("expected RequestContext to be set")
+		}
+		if capturedRC.User == nil || capturedRC.User.Username != "admin" {
+			t.Error("expected synthetic admin user")
+		}
+		if capturedRC.AuthEnabled {
+			t.Error("expected AuthEnabled to be false")
+		}
+		if len(capturedRC.Permissions) != len(AllPermissions()) {
+			t.Errorf("expected all permissions, got %d", len(capturedRC.Permissions))
+		}
+	})
+
+	t.Run("auth enabled with no credentials redirects browser to login", func(t *testing.T) {
+		svc := newTestService(true)
+
+		handler := AuthMiddleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusSeeOther {
+			t.Fatalf("expected 303 redirect, got %d", w.Code)
+		}
+		location := w.Header().Get("Location")
+		if location != "/login" {
+			t.Errorf("expected redirect to /login, got %q", location)
+		}
+	})
+
+	t.Run("auth enabled with no credentials returns 401 for API request", func(t *testing.T) {
+		svc := newTestService(true)
+
+		handler := AuthMiddleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/api/containers", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("auth enabled with valid session passes through", func(t *testing.T) {
+		svc := newTestService(true)
+
+		// Create a user and session in the mock stores.
+		hash, _ := HashPassword("TestPass1")
+		user := User{
+			ID:           "user1",
+			Username:     "testuser",
+			PasswordHash: hash,
+			RoleID:       RoleAdminID,
+		}
+		_ = svc.Users.CreateUser(user)
+
+		session := Session{
+			Token:     "valid-session-token",
+			UserID:    "user1",
+			CreatedAt: time.Now(),
+			ExpiresAt: time.Now().Add(24 * time.Hour),
+		}
+		_ = svc.Sessions.CreateSession(session)
+
+		var capturedRC *RequestContext
+		handler := AuthMiddleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedRC = GetRequestContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "valid-session-token"})
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		if capturedRC == nil {
+			t.Fatal("expected RequestContext to be set")
+		}
+		if capturedRC.User.ID != "user1" {
+			t.Errorf("expected user ID %q, got %q", "user1", capturedRC.User.ID)
+		}
+		if !capturedRC.AuthEnabled {
+			t.Error("expected AuthEnabled to be true")
+		}
+	})
+
+	t.Run("auth enabled with invalid bearer returns 401", func(t *testing.T) {
+		svc := newTestService(true)
+
+		handler := AuthMiddleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/api/data", nil)
+		req.Header.Set("Authorization", "Bearer invalid-token")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("auth enabled with valid bearer token passes through", func(t *testing.T) {
+		svc := newTestService(true)
+
+		// Create a user.
+		hash, _ := HashPassword("TestPass1")
+		user := User{
+			ID:           "user2",
+			Username:     "apiuser",
+			PasswordHash: hash,
+			RoleID:       RoleAdminID,
+		}
+		_ = svc.Users.CreateUser(user)
+
+		// Create an API token.
+		plaintext, tokenHash, _ := GenerateAPIToken()
+		apiToken := APIToken{
+			ID:        "tok1",
+			Name:      "test-token",
+			TokenHash: tokenHash,
+			UserID:    "user2",
+		}
+		_ = svc.Tokens.CreateAPIToken(apiToken)
+
+		var capturedRC *RequestContext
+		handler := AuthMiddleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedRC = GetRequestContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/api/data", nil)
+		req.Header.Set("Authorization", "Bearer "+plaintext)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		if capturedRC == nil {
+			t.Fatal("expected RequestContext to be set")
+		}
+		if capturedRC.User.ID != "user2" {
+			t.Errorf("expected user ID %q, got %q", "user2", capturedRC.User.ID)
+		}
+		if capturedRC.APIToken == nil {
+			t.Error("expected APIToken to be set in context")
+		}
+	})
+}
+
+func TestCSRFMiddleware(t *testing.T) {
+	t.Run("passes GET requests through", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/dashboard", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if !called {
+			t.Error("expected handler to be called for GET request")
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("passes HEAD requests through", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+
+		req := httptest.NewRequest("HEAD", "/dashboard", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if !called {
+			t.Error("expected handler to be called for HEAD request")
+		}
+	})
+
+	t.Run("passes OPTIONS requests through", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+
+		req := httptest.NewRequest("OPTIONS", "/dashboard", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if !called {
+			t.Error("expected handler to be called for OPTIONS request")
+		}
+	})
+
+	t.Run("passes POST with bearer token (API exempt)", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("POST", "/api/action", nil)
+		req.Header.Set("Authorization", "Bearer some-api-token")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if !called {
+			t.Error("expected handler to be called for bearer-token POST (CSRF exempt)")
+		}
+	})
+
+	t.Run("passes POST when auth disabled", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		// Inject a RequestContext with AuthEnabled=false.
+		rc := &RequestContext{
+			User:        &User{ID: "system", Username: "admin"},
+			Permissions: AllPermissions(),
+			AuthEnabled: false,
+		}
+		req := httptest.NewRequest("POST", "/action", nil)
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if !called {
+			t.Error("expected handler to be called when auth is disabled")
+		}
+	})
+
+	t.Run("blocks POST without CSRF token", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+
+		// Inject auth-enabled context so CSRF check runs.
+		rc := &RequestContext{
+			User:        &User{ID: "u1"},
+			AuthEnabled: true,
+		}
+		req := httptest.NewRequest("POST", "/action", nil)
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if called {
+			t.Error("expected handler NOT to be called without CSRF token")
+		}
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", w.Code)
+		}
+	})
+
+	t.Run("passes POST with valid CSRF double-submit", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		rc := &RequestContext{
+			User:        &User{ID: "u1"},
+			AuthEnabled: true,
+		}
+		req := httptest.NewRequest("POST", "/action", nil)
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: "csrf-match"})
+		req.Header.Set(CSRFHeaderName, "csrf-match")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if !called {
+			t.Error("expected handler to be called with valid CSRF tokens")
+		}
+	})
+
+	t.Run("blocks DELETE without CSRF", func(t *testing.T) {
+		called := false
+		handler := CSRFMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+
+		rc := &RequestContext{
+			User:        &User{ID: "u1"},
+			AuthEnabled: true,
+		}
+		req := httptest.NewRequest("DELETE", "/api/resource", nil)
+		req.Header.Set("Accept", "application/json")
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if called {
+			t.Error("expected handler NOT to be called for DELETE without CSRF")
+		}
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", w.Code)
+		}
+	})
+}
+
+func TestRequirePermission(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("blocks without RequestContext", func(t *testing.T) {
+		handler := RequirePermission(PermContainersView)(okHandler)
+
+		req := httptest.NewRequest("GET", "/containers", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", w.Code)
+		}
+	})
+
+	t.Run("blocks without required permission", func(t *testing.T) {
+		handler := RequirePermission(PermSettingsModify)(okHandler)
+
+		rc := &RequestContext{
+			User:        &User{ID: "u1"},
+			Permissions: []Permission{PermContainersView, PermLogsView},
+			AuthEnabled: true,
+		}
+		req := httptest.NewRequest("GET", "/settings", nil)
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", w.Code)
+		}
+	})
+
+	t.Run("passes with required permission", func(t *testing.T) {
+		handler := RequirePermission(PermContainersView)(okHandler)
+
+		rc := &RequestContext{
+			User:        &User{ID: "u1"},
+			Permissions: []Permission{PermContainersView, PermLogsView},
+			AuthEnabled: true,
+		}
+		req := httptest.NewRequest("GET", "/containers", nil)
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("returns 403 JSON for API request without permission", func(t *testing.T) {
+		handler := RequirePermission(PermUsersManage)(okHandler)
+
+		rc := &RequestContext{
+			User:        &User{ID: "u1"},
+			Permissions: []Permission{PermContainersView},
+			AuthEnabled: true,
+		}
+		req := httptest.NewRequest("GET", "/api/users", nil)
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if body == "" || body[0] != '{' {
+			t.Errorf("expected JSON error body for API request, got %q", body)
+		}
+	})
+
+	t.Run("returns HTML for browser request without permission", func(t *testing.T) {
+		handler := RequirePermission(PermUsersManage)(okHandler)
+
+		rc := &RequestContext{
+			User:        &User{ID: "u1"},
+			Permissions: []Permission{PermContainersView},
+			AuthEnabled: true,
+		}
+		req := httptest.NewRequest("GET", "/users", nil)
+		req.Header.Set("Accept", "text/html")
+		req = req.WithContext(context.WithValue(req.Context(), ContextKey, rc))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if len(body) > 0 && body[0] == '{' {
+			t.Errorf("expected non-JSON body for browser request, got %q", body)
+		}
+	})
+}
+
+func TestHasPermission(t *testing.T) {
+	t.Run("returns true when permission exists", func(t *testing.T) {
+		rc := &RequestContext{
+			Permissions: []Permission{PermContainersView, PermLogsView},
+		}
+		if !rc.HasPermission(PermContainersView) {
+			t.Error("expected HasPermission to return true")
+		}
+	})
+
+	t.Run("returns false when permission missing", func(t *testing.T) {
+		rc := &RequestContext{
+			Permissions: []Permission{PermContainersView},
+		}
+		if rc.HasPermission(PermUsersManage) {
+			t.Error("expected HasPermission to return false")
+		}
+	})
+
+	t.Run("returns false for empty permissions", func(t *testing.T) {
+		rc := &RequestContext{}
+		if rc.HasPermission(PermContainersView) {
+			t.Error("expected HasPermission to return false for empty permissions")
+		}
+	})
+}

--- a/internal/auth/mock_stores_test.go
+++ b/internal/auth/mock_stores_test.go
@@ -1,0 +1,288 @@
+package auth
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// mockUserStore is an in-memory implementation of UserStore for testing.
+type mockUserStore struct {
+	mu    sync.Mutex
+	users map[string]User // keyed by ID
+}
+
+func newMockUserStore() *mockUserStore {
+	return &mockUserStore{users: make(map[string]User)}
+}
+
+func (m *mockUserStore) CreateUser(user User) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.users[user.ID]; exists {
+		return fmt.Errorf("user %q already exists", user.ID)
+	}
+	m.users[user.ID] = user
+	return nil
+}
+
+func (m *mockUserStore) GetUser(id string) (*User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	u, ok := m.users[id]
+	if !ok {
+		return nil, nil
+	}
+	return &u, nil
+}
+
+func (m *mockUserStore) GetUserByUsername(username string) (*User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, u := range m.users {
+		if u.Username == username {
+			return &u, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockUserStore) UpdateUser(user User) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.users[user.ID] = user
+	return nil
+}
+
+func (m *mockUserStore) DeleteUser(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.users, id)
+	return nil
+}
+
+func (m *mockUserStore) ListUsers() ([]User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []User
+	for _, u := range m.users {
+		result = append(result, u)
+	}
+	return result, nil
+}
+
+func (m *mockUserStore) UserCount() (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.users), nil
+}
+
+func (m *mockUserStore) CreateFirstUser(user User) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.users) > 0 {
+		return ErrUsersExist
+	}
+	m.users[user.ID] = user
+	return nil
+}
+
+// mockSessionStore is an in-memory implementation of SessionStore for testing.
+type mockSessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]Session // keyed by token
+}
+
+func newMockSessionStore() *mockSessionStore {
+	return &mockSessionStore{sessions: make(map[string]Session)}
+}
+
+func (m *mockSessionStore) CreateSession(session Session) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[session.Token] = session
+	return nil
+}
+
+func (m *mockSessionStore) GetSession(token string) (*Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[token]
+	if !ok {
+		return nil, nil
+	}
+	return &s, nil
+}
+
+func (m *mockSessionStore) DeleteSession(token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, token)
+	return nil
+}
+
+func (m *mockSessionStore) DeleteSessionsForUser(userID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, s := range m.sessions {
+		if s.UserID == userID {
+			delete(m.sessions, k)
+		}
+	}
+	return nil
+}
+
+func (m *mockSessionStore) ListSessionsForUser(userID string) ([]Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []Session
+	for _, s := range m.sessions {
+		if s.UserID == userID {
+			result = append(result, s)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockSessionStore) DeleteExpiredSessions() (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	count := 0
+	for k, s := range m.sessions {
+		if now.After(s.ExpiresAt) {
+			delete(m.sessions, k)
+			count++
+		}
+	}
+	return count, nil
+}
+
+// mockRoleStore is an in-memory implementation of RoleStore for testing.
+type mockRoleStore struct {
+	mu    sync.Mutex
+	roles map[string]Role
+}
+
+func newMockRoleStore() *mockRoleStore {
+	store := &mockRoleStore{roles: make(map[string]Role)}
+	// Seed built-in roles by default.
+	for _, r := range BuiltinRoles() {
+		store.roles[r.ID] = r
+	}
+	return store
+}
+
+func (m *mockRoleStore) GetRole(id string) (*Role, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.roles[id]
+	if !ok {
+		return nil, nil
+	}
+	return &r, nil
+}
+
+func (m *mockRoleStore) ListRoles() ([]Role, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []Role
+	for _, r := range m.roles {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func (m *mockRoleStore) SeedBuiltinRoles() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, r := range BuiltinRoles() {
+		m.roles[r.ID] = r
+	}
+	return nil
+}
+
+// mockAPITokenStore is an in-memory implementation of APITokenStore for testing.
+type mockAPITokenStore struct {
+	mu     sync.Mutex
+	tokens map[string]APIToken // keyed by ID
+}
+
+func newMockAPITokenStore() *mockAPITokenStore {
+	return &mockAPITokenStore{tokens: make(map[string]APIToken)}
+}
+
+func (m *mockAPITokenStore) CreateAPIToken(token APIToken) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tokens[token.ID] = token
+	return nil
+}
+
+func (m *mockAPITokenStore) GetAPITokenByHash(hash string) (*APIToken, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.tokens {
+		if t.TokenHash == hash {
+			return &t, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockAPITokenStore) DeleteAPIToken(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.tokens, id)
+	return nil
+}
+
+func (m *mockAPITokenStore) ListAPITokensForUser(userID string) ([]APIToken, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []APIToken
+	for _, t := range m.tokens {
+		if t.UserID == userID {
+			result = append(result, t)
+		}
+	}
+	return result, nil
+}
+
+// mockSettingsReader is an in-memory implementation of SettingsReader for testing.
+type mockSettingsReader struct {
+	mu       sync.Mutex
+	settings map[string]string
+}
+
+func newMockSettingsReader() *mockSettingsReader {
+	return &mockSettingsReader{settings: make(map[string]string)}
+}
+
+func (m *mockSettingsReader) LoadSetting(key string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.settings[key], nil
+}
+
+func (m *mockSettingsReader) SaveSetting(key, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.settings[key] = value
+	return nil
+}
+
+// newTestService creates a Service with mock stores for testing.
+func newTestService(authEnabled bool) *Service {
+	enabled := authEnabled
+	return NewService(ServiceConfig{
+		Users:          newMockUserStore(),
+		Sessions:       newMockSessionStore(),
+		Roles:          newMockRoleStore(),
+		Tokens:         newMockAPITokenStore(),
+		Settings:       newMockSettingsReader(),
+		CookieSecure:   false,
+		SessionExpiry:  24 * time.Hour,
+		AuthEnabledEnv: &enabled,
+	})
+}

--- a/internal/auth/passwords.go
+++ b/internal/auth/passwords.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"errors"
+	"unicode"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const bcryptCost = 12
+
+var (
+	ErrPasswordTooShort = errors.New("password must be at least 8 characters")
+	ErrPasswordNoLetter = errors.New("password must contain at least one letter")
+	ErrPasswordNoDigit  = errors.New("password must contain at least one digit")
+)
+
+// ValidatePassword checks the password meets the minimum policy.
+func ValidatePassword(password string) error {
+	if len(password) < 8 {
+		return ErrPasswordTooShort
+	}
+	var hasLetter, hasDigit bool
+	for _, r := range password {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+		}
+		if unicode.IsDigit(r) {
+			hasDigit = true
+		}
+	}
+	if !hasLetter {
+		return ErrPasswordNoLetter
+	}
+	if !hasDigit {
+		return ErrPasswordNoDigit
+	}
+	return nil
+}
+
+// HashPassword returns a bcrypt hash of the password.
+func HashPassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+// CheckPassword verifies a password against a bcrypt hash.
+func CheckPassword(hash, password string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil
+}

--- a/internal/auth/passwords_test.go
+++ b/internal/auth/passwords_test.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestValidatePassword(t *testing.T) {
+	t.Run("too short", func(t *testing.T) {
+		err := ValidatePassword("Ab1")
+		if err != ErrPasswordTooShort {
+			t.Errorf("expected ErrPasswordTooShort, got %v", err)
+		}
+	})
+
+	t.Run("exactly 7 chars is too short", func(t *testing.T) {
+		err := ValidatePassword("Abcde1x")
+		if err != ErrPasswordTooShort {
+			t.Errorf("expected ErrPasswordTooShort, got %v", err)
+		}
+	})
+
+	t.Run("no letter", func(t *testing.T) {
+		err := ValidatePassword("12345678")
+		if err != ErrPasswordNoLetter {
+			t.Errorf("expected ErrPasswordNoLetter, got %v", err)
+		}
+	})
+
+	t.Run("no digit", func(t *testing.T) {
+		err := ValidatePassword("abcdefgh")
+		if err != ErrPasswordNoDigit {
+			t.Errorf("expected ErrPasswordNoDigit, got %v", err)
+		}
+	})
+
+	t.Run("valid password", func(t *testing.T) {
+		err := ValidatePassword("Secret99")
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("exactly 8 chars valid", func(t *testing.T) {
+		err := ValidatePassword("Abcdefg1")
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		err := ValidatePassword("")
+		if err != ErrPasswordTooShort {
+			t.Errorf("expected ErrPasswordTooShort, got %v", err)
+		}
+	})
+}
+
+func TestHashAndCheckPassword(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		password := "MySecret42"
+		hash, err := HashPassword(password)
+		if err != nil {
+			t.Fatalf("HashPassword failed: %v", err)
+		}
+		if hash == "" {
+			t.Fatal("expected non-empty hash")
+		}
+		if hash == password {
+			t.Fatal("hash should not equal plaintext password")
+		}
+		if !CheckPassword(hash, password) {
+			t.Error("CheckPassword should return true for correct password")
+		}
+	})
+
+	t.Run("wrong password", func(t *testing.T) {
+		hash, err := HashPassword("CorrectPassword1")
+		if err != nil {
+			t.Fatalf("HashPassword failed: %v", err)
+		}
+		if CheckPassword(hash, "WrongPassword1") {
+			t.Error("CheckPassword should return false for wrong password")
+		}
+	})
+
+	t.Run("different hashes for same password", func(t *testing.T) {
+		hash1, err := HashPassword("SamePass99")
+		if err != nil {
+			t.Fatalf("HashPassword failed: %v", err)
+		}
+		hash2, err := HashPassword("SamePass99")
+		if err != nil {
+			t.Fatalf("HashPassword failed: %v", err)
+		}
+		if hash1 == hash2 {
+			t.Error("bcrypt should produce different hashes for the same password (different salts)")
+		}
+		// Both should still verify correctly.
+		if !CheckPassword(hash1, "SamePass99") {
+			t.Error("hash1 should verify")
+		}
+		if !CheckPassword(hash2, "SamePass99") {
+			t.Error("hash2 should verify")
+		}
+	})
+}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -1,0 +1,62 @@
+package auth
+
+// Built-in role IDs.
+const (
+	RoleAdminID    = "admin"
+	RoleOperatorID = "operator"
+	RoleViewerID   = "viewer"
+)
+
+// BuiltinRoles returns the three default roles.
+func BuiltinRoles() []Role {
+	return []Role{
+		{
+			ID:          RoleAdminID,
+			Name:        "Admin",
+			Permissions: AllPermissions(),
+			BuiltIn:     true,
+		},
+		{
+			ID:   RoleOperatorID,
+			Name: "Operator",
+			Permissions: []Permission{
+				PermContainersView, PermContainersUpdate, PermContainersApprove,
+				PermContainersRollback, PermContainersManage, PermSettingsView,
+				PermLogsView, PermHistoryView,
+			},
+			BuiltIn: true,
+		},
+		{
+			ID:   RoleViewerID,
+			Name: "Viewer",
+			Permissions: []Permission{
+				PermContainersView, PermSettingsView, PermLogsView, PermHistoryView,
+			},
+			BuiltIn: true,
+		},
+	}
+}
+
+// ResolvePermissions returns the effective permissions for a user given their role.
+// If the role has permissions, those are used. APIToken permissions (if non-nil) restrict further.
+func ResolvePermissions(role *Role, tokenPerms []Permission) []Permission {
+	if role == nil {
+		return nil
+	}
+	rolePerms := role.Permissions
+	if tokenPerms == nil {
+		return rolePerms
+	}
+	// Intersect: only grant permissions that exist in both the role and the token scope.
+	allowed := make(map[Permission]bool)
+	for _, p := range rolePerms {
+		allowed[p] = true
+	}
+	var result []Permission
+	for _, p := range tokenPerms {
+		if allowed[p] {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -1,0 +1,156 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestBuiltinRoles(t *testing.T) {
+	roles := BuiltinRoles()
+
+	t.Run("returns three roles", func(t *testing.T) {
+		if len(roles) != 3 {
+			t.Fatalf("expected 3 built-in roles, got %d", len(roles))
+		}
+	})
+
+	findRole := func(id string) *Role {
+		t.Helper()
+		for i := range roles {
+			if roles[i].ID == id {
+				return &roles[i]
+			}
+		}
+		t.Fatalf("role %q not found", id)
+		return nil
+	}
+
+	t.Run("admin has 10 permissions", func(t *testing.T) {
+		admin := findRole(RoleAdminID)
+		if len(admin.Permissions) != 10 {
+			t.Errorf("expected admin to have 10 permissions, got %d", len(admin.Permissions))
+		}
+		if !admin.BuiltIn {
+			t.Error("admin role should be built-in")
+		}
+	})
+
+	t.Run("operator has 8 permissions", func(t *testing.T) {
+		op := findRole(RoleOperatorID)
+		if len(op.Permissions) != 8 {
+			t.Errorf("expected operator to have 8 permissions, got %d", len(op.Permissions))
+		}
+		if !op.BuiltIn {
+			t.Error("operator role should be built-in")
+		}
+	})
+
+	t.Run("viewer has 4 permissions", func(t *testing.T) {
+		viewer := findRole(RoleViewerID)
+		if len(viewer.Permissions) != 4 {
+			t.Errorf("expected viewer to have 4 permissions, got %d", len(viewer.Permissions))
+		}
+		if !viewer.BuiltIn {
+			t.Error("viewer role should be built-in")
+		}
+	})
+
+	t.Run("admin has all permissions", func(t *testing.T) {
+		admin := findRole(RoleAdminID)
+		all := AllPermissions()
+		if len(admin.Permissions) != len(all) {
+			t.Errorf("admin should have all %d permissions, has %d", len(all), len(admin.Permissions))
+		}
+		allMap := make(map[Permission]bool)
+		for _, p := range all {
+			allMap[p] = true
+		}
+		for _, p := range admin.Permissions {
+			if !allMap[p] {
+				t.Errorf("admin permission %q not in AllPermissions()", p)
+			}
+		}
+	})
+}
+
+func TestResolvePermissions(t *testing.T) {
+	t.Run("nil role returns nil", func(t *testing.T) {
+		result := ResolvePermissions(nil, nil)
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("nil role with token perms returns nil", func(t *testing.T) {
+		result := ResolvePermissions(nil, []Permission{PermContainersView})
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("role with nil token perms returns role perms", func(t *testing.T) {
+		role := &Role{
+			ID:          "test",
+			Permissions: []Permission{PermContainersView, PermLogsView},
+		}
+		result := ResolvePermissions(role, nil)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 permissions, got %d", len(result))
+		}
+		if result[0] != PermContainersView || result[1] != PermLogsView {
+			t.Errorf("unexpected permissions: %v", result)
+		}
+	})
+
+	t.Run("intersects role and token perms", func(t *testing.T) {
+		role := &Role{
+			ID:          "test",
+			Permissions: []Permission{PermContainersView, PermContainersUpdate, PermLogsView},
+		}
+		tokenPerms := []Permission{PermContainersView, PermLogsView, PermSettingsView}
+
+		result := ResolvePermissions(role, tokenPerms)
+		if len(result) != 2 {
+			t.Fatalf("expected 2 permissions (intersection), got %d: %v", len(result), result)
+		}
+		// Result should contain only the permissions in both sets.
+		resultMap := make(map[Permission]bool)
+		for _, p := range result {
+			resultMap[p] = true
+		}
+		if !resultMap[PermContainersView] {
+			t.Error("expected PermContainersView in intersection")
+		}
+		if !resultMap[PermLogsView] {
+			t.Error("expected PermLogsView in intersection")
+		}
+		if resultMap[PermSettingsView] {
+			t.Error("PermSettingsView should NOT be in intersection (not in role)")
+		}
+		if resultMap[PermContainersUpdate] {
+			t.Error("PermContainersUpdate should NOT be in intersection (not in token)")
+		}
+	})
+
+	t.Run("empty token perms returns empty result", func(t *testing.T) {
+		role := &Role{
+			ID:          "test",
+			Permissions: []Permission{PermContainersView},
+		}
+		result := ResolvePermissions(role, []Permission{})
+		if len(result) != 0 {
+			t.Errorf("expected empty result for empty token perms, got %v", result)
+		}
+	})
+
+	t.Run("no overlap returns empty result", func(t *testing.T) {
+		role := &Role{
+			ID:          "test",
+			Permissions: []Permission{PermContainersView},
+		}
+		tokenPerms := []Permission{PermSettingsModify}
+		result := ResolvePermissions(role, tokenPerms)
+		if len(result) != 0 {
+			t.Errorf("expected empty result for no overlap, got %v", result)
+		}
+	})
+}

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -1,0 +1,115 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	maxLoginAttempts  = 5 // per IP within the window
+	loginWindow       = 5 * time.Minute
+	accountLockout    = 10 // consecutive failures before lockout
+	accountLockoutDur = 30 * time.Minute
+)
+
+// LoginAttempt tracks login attempts for an IP.
+type LoginAttempt struct {
+	Count     int
+	FirstAt   time.Time
+	BlockedAt time.Time // non-zero if blocked
+}
+
+// RateLimiter tracks per-IP login attempt rates.
+type RateLimiter struct {
+	mu       sync.Mutex
+	attempts map[string]*LoginAttempt
+}
+
+// NewRateLimiter creates a new login rate limiter.
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{
+		attempts: make(map[string]*LoginAttempt),
+	}
+}
+
+// Allow checks if a login attempt from the given IP is allowed.
+// Returns true if allowed, false if rate-limited.
+func (rl *RateLimiter) Allow(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	a, ok := rl.attempts[ip]
+	if !ok {
+		rl.attempts[ip] = &LoginAttempt{Count: 1, FirstAt: now}
+		return true
+	}
+
+	// If blocked, check if cooldown has expired.
+	if !a.BlockedAt.IsZero() {
+		if now.Before(a.BlockedAt.Add(accountLockoutDur)) {
+			return false
+		}
+		// Cooldown expired — reset.
+		a.Count = 1
+		a.FirstAt = now
+		a.BlockedAt = time.Time{}
+		return true
+	}
+
+	// Reset window if it's expired.
+	if now.After(a.FirstAt.Add(loginWindow)) {
+		a.Count = 1
+		a.FirstAt = now
+		return true
+	}
+
+	a.Count++
+	if a.Count > maxLoginAttempts {
+		a.BlockedAt = now
+		return false
+	}
+	return true
+}
+
+// RecordFailure records a failed login for an IP. Used for exponential backoff.
+func (rl *RateLimiter) RecordFailure(ip string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	a, ok := rl.attempts[ip]
+	if !ok {
+		rl.attempts[ip] = &LoginAttempt{Count: 1, FirstAt: time.Now()}
+		return
+	}
+	a.Count++
+	if a.Count >= accountLockout {
+		a.BlockedAt = time.Now()
+	}
+}
+
+// Reset clears rate limit state for an IP (called on successful login).
+func (rl *RateLimiter) Reset(ip string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	delete(rl.attempts, ip)
+}
+
+// Cleanup removes expired entries. Call periodically.
+func (rl *RateLimiter) Cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	for ip, a := range rl.attempts {
+		if !a.BlockedAt.IsZero() {
+			if now.After(a.BlockedAt.Add(accountLockoutDur)) {
+				delete(rl.attempts, ip)
+			}
+			continue
+		}
+		if now.After(a.FirstAt.Add(loginWindow)) {
+			delete(rl.attempts, ip)
+		}
+	}
+}

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -1,0 +1,110 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestRateLimiter(t *testing.T) {
+	t.Run("Allow returns true initially", func(t *testing.T) {
+		rl := NewRateLimiter()
+		if !rl.Allow("192.168.1.1") {
+			t.Error("expected Allow to return true for a new IP")
+		}
+	})
+
+	t.Run("allows up to maxLoginAttempts", func(t *testing.T) {
+		rl := NewRateLimiter()
+		ip := "10.0.0.1"
+		for i := 0; i < maxLoginAttempts; i++ {
+			if !rl.Allow(ip) {
+				t.Errorf("expected Allow to return true on attempt %d", i+1)
+			}
+		}
+	})
+
+	t.Run("blocks after exceeding maxLoginAttempts", func(t *testing.T) {
+		rl := NewRateLimiter()
+		ip := "10.0.0.2"
+		// Use up the allowed attempts.
+		for i := 0; i < maxLoginAttempts; i++ {
+			rl.Allow(ip)
+		}
+		// The next call should set blocked (count goes to maxLoginAttempts+1).
+		if rl.Allow(ip) {
+			t.Error("expected Allow to return false after exceeding maxLoginAttempts")
+		}
+		// Subsequent calls should also be blocked.
+		if rl.Allow(ip) {
+			t.Error("expected Allow to remain false while blocked")
+		}
+	})
+
+	t.Run("RecordFailure triggers lockout at threshold", func(t *testing.T) {
+		rl := NewRateLimiter()
+		ip := "10.0.0.3"
+		for i := 0; i < accountLockout; i++ {
+			rl.RecordFailure(ip)
+		}
+		// After accountLockout failures, the IP should be blocked.
+		if rl.Allow(ip) {
+			t.Error("expected Allow to return false after accountLockout RecordFailure calls")
+		}
+	})
+
+	t.Run("Reset clears failures", func(t *testing.T) {
+		rl := NewRateLimiter()
+		ip := "10.0.0.4"
+		// Record enough failures to trigger lockout.
+		for i := 0; i < accountLockout; i++ {
+			rl.RecordFailure(ip)
+		}
+		if rl.Allow(ip) {
+			t.Error("expected blocked before reset")
+		}
+		rl.Reset(ip)
+		if !rl.Allow(ip) {
+			t.Error("expected Allow to return true after Reset")
+		}
+	})
+
+	t.Run("different IPs are independent", func(t *testing.T) {
+		rl := NewRateLimiter()
+		ip1 := "10.0.0.10"
+		ip2 := "10.0.0.11"
+
+		// Lock out ip1.
+		for i := 0; i < accountLockout; i++ {
+			rl.RecordFailure(ip1)
+		}
+		if rl.Allow(ip1) {
+			t.Error("ip1 should be blocked")
+		}
+
+		// ip2 should still be allowed.
+		if !rl.Allow(ip2) {
+			t.Error("ip2 should not be affected by ip1 being blocked")
+		}
+	})
+
+	t.Run("Cleanup removes expired entries", func(t *testing.T) {
+		rl := NewRateLimiter()
+		ip := "10.0.0.20"
+		// Create an entry.
+		rl.Allow(ip)
+
+		rl.mu.Lock()
+		// Manually backdate the entry so it appears expired.
+		a := rl.attempts[ip]
+		a.FirstAt = a.FirstAt.Add(-(loginWindow + 1))
+		rl.mu.Unlock()
+
+		rl.Cleanup()
+
+		rl.mu.Lock()
+		_, exists := rl.attempts[ip]
+		rl.mu.Unlock()
+		if exists {
+			t.Error("expected expired entry to be cleaned up")
+		}
+	})
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,291 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// UserStore is the interface for user persistence.
+type UserStore interface {
+	CreateUser(user User) error
+	GetUser(id string) (*User, error)
+	GetUserByUsername(username string) (*User, error)
+	UpdateUser(user User) error
+	DeleteUser(id string) error
+	ListUsers() ([]User, error)
+	UserCount() (int, error)
+	// CreateFirstUser atomically creates a user only if no users exist.
+	// Returns ErrUsersExist if any users already exist (race protection).
+	CreateFirstUser(user User) error
+}
+
+// SessionStore is the interface for session persistence.
+type SessionStore interface {
+	CreateSession(session Session) error
+	GetSession(token string) (*Session, error)
+	DeleteSession(token string) error
+	DeleteSessionsForUser(userID string) error
+	ListSessionsForUser(userID string) ([]Session, error)
+	DeleteExpiredSessions() (int, error)
+}
+
+// RoleStore is the interface for role persistence.
+type RoleStore interface {
+	GetRole(id string) (*Role, error)
+	ListRoles() ([]Role, error)
+	SeedBuiltinRoles() error
+}
+
+// APITokenStore is the interface for API token persistence.
+type APITokenStore interface {
+	CreateAPIToken(token APIToken) error
+	GetAPITokenByHash(hash string) (*APIToken, error)
+	DeleteAPIToken(id string) error
+	ListAPITokensForUser(userID string) ([]APIToken, error)
+}
+
+// SettingsReader reads auth-related settings from the settings bucket.
+type SettingsReader interface {
+	LoadSetting(key string) (string, error)
+	SaveSetting(key, value string) error
+}
+
+// Service aggregates all auth-related stores and configuration.
+type Service struct {
+	Users    UserStore
+	Sessions SessionStore
+	Roles    RoleStore
+	Tokens   APITokenStore
+	Settings SettingsReader
+	Log      *slog.Logger
+
+	CookieSecure   bool
+	SessionExpiry  time.Duration
+	AuthEnabledEnv *bool // nil = use DB setting; non-nil = override
+
+	rateLimiter *RateLimiter
+}
+
+// NewService creates a new auth service.
+func NewService(cfg ServiceConfig) *Service {
+	return &Service{
+		Users:          cfg.Users,
+		Sessions:       cfg.Sessions,
+		Roles:          cfg.Roles,
+		Tokens:         cfg.Tokens,
+		Settings:       cfg.Settings,
+		Log:            cfg.Log,
+		CookieSecure:   cfg.CookieSecure,
+		SessionExpiry:  cfg.SessionExpiry,
+		AuthEnabledEnv: cfg.AuthEnabledEnv,
+		rateLimiter:    NewRateLimiter(),
+	}
+}
+
+// ServiceConfig holds the configuration for creating a Service.
+type ServiceConfig struct {
+	Users          UserStore
+	Sessions       SessionStore
+	Roles          RoleStore
+	Tokens         APITokenStore
+	Settings       SettingsReader
+	Log            *slog.Logger
+	CookieSecure   bool
+	SessionExpiry  time.Duration
+	AuthEnabledEnv *bool // env var override for auth_enabled
+}
+
+// AuthEnabled returns whether auth is currently enabled.
+func (s *Service) AuthEnabled() bool {
+	// Env var override takes precedence.
+	if s.AuthEnabledEnv != nil {
+		return *s.AuthEnabledEnv
+	}
+	// Check DB setting.
+	val, err := s.Settings.LoadSetting("auth_enabled")
+	if err != nil || val == "" {
+		return true // default: enabled
+	}
+	return val != "false"
+}
+
+// SetupComplete returns whether initial setup has been completed.
+func (s *Service) SetupComplete() bool {
+	val, err := s.Settings.LoadSetting("auth_setup_complete")
+	if err != nil {
+		return false
+	}
+	return val == "true"
+}
+
+// NeedsSetup returns true if the setup wizard should be shown.
+func (s *Service) NeedsSetup() bool {
+	if s.SetupComplete() {
+		return false
+	}
+	count, err := s.Users.UserCount()
+	if err != nil {
+		return false
+	}
+	return count == 0
+}
+
+// GenerateBootstrapToken creates a one-time setup token.
+func GenerateBootstrapToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// GenerateUserID creates a random 16-char hex user ID.
+func GenerateUserID() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// Login authenticates a user and creates a session.
+// Returns the session token and user on success.
+func (s *Service) Login(ctx context.Context, username, password, ip, userAgent string) (*Session, *User, error) {
+	// Rate limit check.
+	if !s.rateLimiter.Allow(ip) {
+		return nil, nil, ErrRateLimited
+	}
+
+	user, err := s.Users.GetUserByUsername(username)
+	if err != nil || user == nil {
+		s.rateLimiter.RecordFailure(ip)
+		return nil, nil, ErrInvalidCredentials
+	}
+
+	// Check account lockout.
+	if user.Locked && time.Now().Before(user.LockedUntil) {
+		return nil, nil, ErrAccountLocked
+	}
+
+	if !CheckPassword(user.PasswordHash, password) {
+		// Record failure and potentially lock account.
+		user.FailedLogins++
+		if user.FailedLogins >= accountLockout {
+			user.Locked = true
+			user.LockedUntil = time.Now().Add(accountLockoutDur)
+		}
+		_ = s.Users.UpdateUser(*user)
+		s.rateLimiter.RecordFailure(ip)
+		return nil, nil, ErrInvalidCredentials
+	}
+
+	// Success — clear failure counters.
+	user.FailedLogins = 0
+	user.Locked = false
+	user.LockedUntil = time.Time{}
+	_ = s.Users.UpdateUser(*user)
+	s.rateLimiter.Reset(ip)
+
+	// Create new session (session rotation — prevent fixation).
+	token, err := GenerateSessionToken()
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate session token: %w", err)
+	}
+
+	session := Session{
+		Token:     token,
+		UserID:    user.ID,
+		IP:        ip,
+		UserAgent: userAgent,
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(s.SessionExpiry),
+	}
+
+	if err := s.Sessions.CreateSession(session); err != nil {
+		return nil, nil, fmt.Errorf("create session: %w", err)
+	}
+
+	return &session, user, nil
+}
+
+// ValidateSession checks a session token and returns a RequestContext if valid.
+func (s *Service) ValidateSession(ctx context.Context, token string) *RequestContext {
+	session, err := s.Sessions.GetSession(token)
+	if err != nil || session == nil {
+		return nil
+	}
+
+	// Check expiry.
+	if time.Now().After(session.ExpiresAt) {
+		_ = s.Sessions.DeleteSession(token)
+		return nil
+	}
+
+	user, err := s.Users.GetUser(session.UserID)
+	if err != nil || user == nil {
+		return nil
+	}
+
+	role, _ := s.Roles.GetRole(user.RoleID)
+	perms := ResolvePermissions(role, nil)
+
+	return &RequestContext{
+		User:        user,
+		Session:     session,
+		Permissions: perms,
+	}
+}
+
+// ValidateBearerToken checks a bearer token and returns a RequestContext if valid.
+func (s *Service) ValidateBearerToken(ctx context.Context, rawToken string) *RequestContext {
+	hash := HashToken(rawToken)
+	apiToken, err := s.Tokens.GetAPITokenByHash(hash)
+	if err != nil || apiToken == nil {
+		return nil
+	}
+
+	// Check expiry.
+	if !apiToken.ExpiresAt.IsZero() && time.Now().After(apiToken.ExpiresAt) {
+		return nil
+	}
+
+	user, err := s.Users.GetUser(apiToken.UserID)
+	if err != nil || user == nil {
+		return nil
+	}
+
+	role, _ := s.Roles.GetRole(user.RoleID)
+	perms := ResolvePermissions(role, apiToken.Permissions)
+
+	// Update last used timestamp (best effort).
+	apiToken.LastUsedAt = time.Now().UTC()
+	// Don't error-check — this is best-effort tracking.
+
+	return &RequestContext{
+		User:        user,
+		APIToken:    apiToken,
+		Permissions: perms,
+	}
+}
+
+// Logout revokes a session.
+func (s *Service) Logout(token string) error {
+	return s.Sessions.DeleteSession(token)
+}
+
+// CleanupExpiredSessions removes expired sessions from the store.
+func (s *Service) CleanupExpiredSessions() (int, error) {
+	return s.Sessions.DeleteExpiredSessions()
+}
+
+// Sentinel errors.
+var (
+	ErrInvalidCredentials = fmt.Errorf("invalid credentials")
+	ErrRateLimited        = fmt.Errorf("too many login attempts")
+	ErrAccountLocked      = fmt.Errorf("account is locked")
+	ErrUsersExist         = fmt.Errorf("users already exist")
+)

--- a/internal/auth/sessions.go
+++ b/internal/auth/sessions.go
@@ -1,0 +1,57 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"time"
+)
+
+const (
+	SessionCookieName = "sentinel_session"
+	sessionTokenBytes = 32 // 32 bytes = 64 hex chars
+)
+
+// GenerateSessionToken creates a cryptographically random 64-char hex token.
+func GenerateSessionToken() (string, error) {
+	b := make([]byte, sessionTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// SetSessionCookie sets the session cookie on the response.
+func SetSessionCookie(w http.ResponseWriter, token string, expiry time.Time, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  expiry,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secure,
+	})
+}
+
+// ClearSessionCookie removes the session cookie.
+func ClearSessionCookie(w http.ResponseWriter, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secure,
+	})
+}
+
+// GetSessionToken extracts the session token from the request cookie.
+func GetSessionToken(r *http.Request) string {
+	cookie, err := r.Cookie(SessionCookieName)
+	if err != nil {
+		return ""
+	}
+	return cookie.Value
+}

--- a/internal/auth/sessions_test.go
+++ b/internal/auth/sessions_test.go
@@ -1,0 +1,139 @@
+package auth
+
+import (
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGenerateSessionToken(t *testing.T) {
+	t.Run("returns 64-char hex string", func(t *testing.T) {
+		token, err := GenerateSessionToken()
+		if err != nil {
+			t.Fatalf("GenerateSessionToken failed: %v", err)
+		}
+		if len(token) != 64 {
+			t.Errorf("expected 64 chars, got %d", len(token))
+		}
+		// Verify it's valid hex.
+		if _, err := hex.DecodeString(token); err != nil {
+			t.Errorf("token is not valid hex: %v", err)
+		}
+	})
+
+	t.Run("tokens are unique", func(t *testing.T) {
+		token1, err := GenerateSessionToken()
+		if err != nil {
+			t.Fatalf("GenerateSessionToken failed: %v", err)
+		}
+		token2, err := GenerateSessionToken()
+		if err != nil {
+			t.Fatalf("GenerateSessionToken failed: %v", err)
+		}
+		if token1 == token2 {
+			t.Error("two generated tokens should not be identical")
+		}
+	})
+}
+
+func TestSetSessionCookie(t *testing.T) {
+	t.Run("sets correct cookie attributes", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		expiry := time.Now().Add(24 * time.Hour)
+		SetSessionCookie(w, "test-token-value", expiry, true)
+
+		resp := w.Result()
+		cookies := resp.Cookies()
+		if len(cookies) != 1 {
+			t.Fatalf("expected 1 cookie, got %d", len(cookies))
+		}
+		c := cookies[0]
+		if c.Name != SessionCookieName {
+			t.Errorf("expected cookie name %q, got %q", SessionCookieName, c.Name)
+		}
+		if c.Value != "test-token-value" {
+			t.Errorf("expected cookie value %q, got %q", "test-token-value", c.Value)
+		}
+		if c.Path != "/" {
+			t.Errorf("expected path '/', got %q", c.Path)
+		}
+		if !c.HttpOnly {
+			t.Error("expected HttpOnly to be true")
+		}
+		if !c.Secure {
+			t.Error("expected Secure to be true when secure=true")
+		}
+		if c.SameSite != http.SameSiteLaxMode {
+			t.Errorf("expected SameSiteLaxMode, got %v", c.SameSite)
+		}
+	})
+
+	t.Run("secure false", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		SetSessionCookie(w, "token", time.Now().Add(time.Hour), false)
+		resp := w.Result()
+		c := resp.Cookies()[0]
+		if c.Secure {
+			t.Error("expected Secure to be false when secure=false")
+		}
+	})
+}
+
+func TestClearSessionCookie(t *testing.T) {
+	t.Run("sets MaxAge -1", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ClearSessionCookie(w, false)
+
+		resp := w.Result()
+		cookies := resp.Cookies()
+		if len(cookies) != 1 {
+			t.Fatalf("expected 1 cookie, got %d", len(cookies))
+		}
+		c := cookies[0]
+		if c.Name != SessionCookieName {
+			t.Errorf("expected cookie name %q, got %q", SessionCookieName, c.Name)
+		}
+		if c.Value != "" {
+			t.Errorf("expected empty cookie value, got %q", c.Value)
+		}
+		if c.MaxAge != -1 {
+			t.Errorf("expected MaxAge -1, got %d", c.MaxAge)
+		}
+	})
+}
+
+func TestGetSessionToken(t *testing.T) {
+	t.Run("extracts from request cookie", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  SessionCookieName,
+			Value: "my-session-token",
+		})
+		got := GetSessionToken(req)
+		if got != "my-session-token" {
+			t.Errorf("expected %q, got %q", "my-session-token", got)
+		}
+	})
+
+	t.Run("returns empty string when no cookie", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		got := GetSessionToken(req)
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns empty string for wrong cookie name", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  "wrong_cookie",
+			Value: "some-value",
+		})
+		got := GetSessionToken(req)
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+}

--- a/internal/auth/tokens.go
+++ b/internal/auth/tokens.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+)
+
+const (
+	TokenPrefix   = "stk_"
+	tokenRawBytes = 32 // 32 bytes of randomness
+	tokenIDBytes  = 8  // 8 bytes = 16 hex chars
+)
+
+// GenerateAPIToken creates a new API token with the stk_ prefix.
+// Returns the full plaintext token (shown once) and the SHA-256 hash for storage.
+func GenerateAPIToken() (plaintext string, hash string, err error) {
+	raw := make([]byte, tokenRawBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", "", err
+	}
+	plaintext = TokenPrefix + base64.RawURLEncoding.EncodeToString(raw)
+	hash = HashToken(plaintext)
+	return plaintext, hash, nil
+}
+
+// GenerateTokenID creates a random 16-char hex ID for API token records.
+func GenerateTokenID() (string, error) {
+	b := make([]byte, tokenIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// HashToken returns the SHA-256 hex digest of a token string.
+func HashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}
+
+// ExtractBearerToken extracts a bearer token from the Authorization header.
+// Returns empty string if not present or malformed.
+func ExtractBearerToken(authHeader string) string {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(authHeader, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(authHeader[len(prefix):])
+}

--- a/internal/auth/tokens_test.go
+++ b/internal/auth/tokens_test.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestGenerateAPIToken(t *testing.T) {
+	t.Run("returns stk_ prefix and non-empty hash", func(t *testing.T) {
+		plaintext, hash, err := GenerateAPIToken()
+		if err != nil {
+			t.Fatalf("GenerateAPIToken failed: %v", err)
+		}
+		if !strings.HasPrefix(plaintext, TokenPrefix) {
+			t.Errorf("expected token to start with %q, got %q", TokenPrefix, plaintext)
+		}
+		if hash == "" {
+			t.Error("expected non-empty hash")
+		}
+		if len(hash) != 64 {
+			t.Errorf("expected 64-char SHA-256 hex hash, got %d chars", len(hash))
+		}
+	})
+
+	t.Run("tokens are unique", func(t *testing.T) {
+		p1, h1, _ := GenerateAPIToken()
+		p2, h2, _ := GenerateAPIToken()
+		if p1 == p2 {
+			t.Error("two generated tokens should not be identical")
+		}
+		if h1 == h2 {
+			t.Error("two generated hashes should not be identical")
+		}
+	})
+
+	t.Run("hash matches HashToken of plaintext", func(t *testing.T) {
+		plaintext, hash, err := GenerateAPIToken()
+		if err != nil {
+			t.Fatalf("GenerateAPIToken failed: %v", err)
+		}
+		if HashToken(plaintext) != hash {
+			t.Error("hash returned by GenerateAPIToken should match HashToken(plaintext)")
+		}
+	})
+}
+
+func TestGenerateTokenID(t *testing.T) {
+	t.Run("returns 16-char hex string", func(t *testing.T) {
+		id, err := GenerateTokenID()
+		if err != nil {
+			t.Fatalf("GenerateTokenID failed: %v", err)
+		}
+		if len(id) != 16 {
+			t.Errorf("expected 16 chars, got %d", len(id))
+		}
+		if _, err := hex.DecodeString(id); err != nil {
+			t.Errorf("token ID is not valid hex: %v", err)
+		}
+	})
+
+	t.Run("IDs are unique", func(t *testing.T) {
+		id1, _ := GenerateTokenID()
+		id2, _ := GenerateTokenID()
+		if id1 == id2 {
+			t.Error("two generated token IDs should not be identical")
+		}
+	})
+}
+
+func TestHashToken(t *testing.T) {
+	t.Run("is deterministic", func(t *testing.T) {
+		token := "stk_some-test-token"
+		h1 := HashToken(token)
+		h2 := HashToken(token)
+		if h1 != h2 {
+			t.Error("HashToken should return the same value for the same input")
+		}
+	})
+
+	t.Run("different inputs produce different hashes", func(t *testing.T) {
+		h1 := HashToken("token-a")
+		h2 := HashToken("token-b")
+		if h1 == h2 {
+			t.Error("different tokens should produce different hashes")
+		}
+	})
+
+	t.Run("returns 64-char hex string", func(t *testing.T) {
+		h := HashToken("anything")
+		if len(h) != 64 {
+			t.Errorf("expected 64 chars, got %d", len(h))
+		}
+		if _, err := hex.DecodeString(h); err != nil {
+			t.Errorf("hash is not valid hex: %v", err)
+		}
+	})
+}
+
+func TestExtractBearerToken(t *testing.T) {
+	t.Run("extracts from Bearer header", func(t *testing.T) {
+		got := ExtractBearerToken("Bearer my-token-123")
+		if got != "my-token-123" {
+			t.Errorf("expected %q, got %q", "my-token-123", got)
+		}
+	})
+
+	t.Run("returns empty for missing prefix", func(t *testing.T) {
+		got := ExtractBearerToken("Basic dXNlcjpwYXNz")
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns empty for empty string", func(t *testing.T) {
+		got := ExtractBearerToken("")
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("trims whitespace from token", func(t *testing.T) {
+		got := ExtractBearerToken("Bearer  token-with-spaces  ")
+		if got != "token-with-spaces" {
+			t.Errorf("expected %q, got %q", "token-with-spaces", got)
+		}
+	})
+
+	t.Run("case sensitive prefix", func(t *testing.T) {
+		got := ExtractBearerToken("bearer my-token")
+		if got != "" {
+			t.Errorf("expected empty string for lowercase 'bearer', got %q", got)
+		}
+	})
+}

--- a/internal/store/bolt_auth.go
+++ b/internal/store/bolt_auth.go
@@ -1,0 +1,606 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/Will-Luck/Docker-Sentinel/internal/auth"
+)
+
+// ---- index key helpers ----
+
+func userIndexKey(username string) []byte {
+	return []byte("idx::username::" + username)
+}
+
+func sessionUserIndexKey(userID, token string) []byte {
+	return []byte("idx::user::" + userID + "::" + token)
+}
+
+func sessionUserIndexPrefix(userID string) []byte {
+	return []byte("idx::user::" + userID + "::")
+}
+
+func apiTokenHashIndexKey(hash string) []byte {
+	return []byte("idx::hash::" + hash)
+}
+
+func apiTokenUserIndexKey(userID, tokenID string) []byte {
+	return []byte("idx::user::" + userID + "::" + tokenID)
+}
+
+func apiTokenUserIndexPrefix(userID string) []byte {
+	return []byte("idx::user::" + userID + "::")
+}
+
+var indexPrefix = []byte("idx::")
+
+func isIndexKey(k []byte) bool {
+	return bytes.HasPrefix(k, indexPrefix)
+}
+
+// ============================================================
+// User CRUD
+// ============================================================
+
+// CreateUser persists a new user and its username index atomically.
+// Returns an error if the username is already taken.
+func (s *Store) CreateUser(user auth.User) error {
+	data, err := json.Marshal(user)
+	if err != nil {
+		return fmt.Errorf("marshal user: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketUsers)
+
+		// Ensure username is unique.
+		if existing := b.Get(userIndexKey(user.Username)); existing != nil {
+			return fmt.Errorf("username %q already exists", user.Username)
+		}
+
+		if err := b.Put([]byte(user.ID), data); err != nil {
+			return err
+		}
+		return b.Put(userIndexKey(user.Username), []byte(user.ID))
+	})
+}
+
+// CreateFirstUser atomically creates the initial user only if no users exist.
+// Returns auth.ErrUsersExist if the users bucket already contains records.
+func (s *Store) CreateFirstUser(user auth.User) error {
+	data, err := json.Marshal(user)
+	if err != nil {
+		return fmt.Errorf("marshal user: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketUsers)
+
+		// Count non-index keys. If any exist, another user beat us.
+		count := 0
+		c := b.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if !isIndexKey(k) {
+				count++
+			}
+		}
+		if count > 0 {
+			return auth.ErrUsersExist
+		}
+
+		if err := b.Put([]byte(user.ID), data); err != nil {
+			return err
+		}
+		return b.Put(userIndexKey(user.Username), []byte(user.ID))
+	})
+}
+
+// GetUser retrieves a user by ID.
+func (s *Store) GetUser(id string) (*auth.User, error) {
+	var user auth.User
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketUsers)
+		v := b.Get([]byte(id))
+		if v == nil {
+			return fmt.Errorf("user %q not found", id)
+		}
+		return json.Unmarshal(v, &user)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+// GetUserByUsername retrieves a user by their unique username.
+func (s *Store) GetUserByUsername(username string) (*auth.User, error) {
+	var user auth.User
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketUsers)
+
+		idBytes := b.Get(userIndexKey(username))
+		if idBytes == nil {
+			return fmt.Errorf("user with username %q not found", username)
+		}
+
+		v := b.Get(idBytes)
+		if v == nil {
+			return fmt.Errorf("user %q index orphan", username)
+		}
+		return json.Unmarshal(v, &user)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+// UpdateUser updates an existing user record. If the username has changed,
+// the secondary index is updated atomically.
+func (s *Store) UpdateUser(user auth.User) error {
+	data, err := json.Marshal(user)
+	if err != nil {
+		return fmt.Errorf("marshal user: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketUsers)
+
+		// Fetch existing to detect username change.
+		existing := b.Get([]byte(user.ID))
+		if existing == nil {
+			return fmt.Errorf("user %q not found", user.ID)
+		}
+
+		var old auth.User
+		if err := json.Unmarshal(existing, &old); err != nil {
+			return fmt.Errorf("unmarshal existing user: %w", err)
+		}
+
+		// If username changed, rotate the index.
+		if old.Username != user.Username {
+			// Check the new username isn't taken by someone else.
+			if v := b.Get(userIndexKey(user.Username)); v != nil {
+				return fmt.Errorf("username %q already exists", user.Username)
+			}
+			if err := b.Delete(userIndexKey(old.Username)); err != nil {
+				return err
+			}
+			if err := b.Put(userIndexKey(user.Username), []byte(user.ID)); err != nil {
+				return err
+			}
+		}
+
+		return b.Put([]byte(user.ID), data)
+	})
+}
+
+// DeleteUser removes a user, its username index, and all associated sessions
+// and API tokens in a single transaction.
+func (s *Store) DeleteUser(id string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		ub := tx.Bucket(bucketUsers)
+
+		// Fetch user to find the username.
+		v := ub.Get([]byte(id))
+		if v == nil {
+			return fmt.Errorf("user %q not found", id)
+		}
+		var user auth.User
+		if err := json.Unmarshal(v, &user); err != nil {
+			return fmt.Errorf("unmarshal user: %w", err)
+		}
+
+		// Delete primary record and username index.
+		if err := ub.Delete([]byte(id)); err != nil {
+			return err
+		}
+		if err := ub.Delete(userIndexKey(user.Username)); err != nil {
+			return err
+		}
+
+		// Cascade-delete sessions for this user.
+		sb := tx.Bucket(bucketSessions)
+		prefix := sessionUserIndexPrefix(id)
+		sc := sb.Cursor()
+		for k, _ := sc.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = sc.Next() {
+			// Extract token from key: idx::user::{userID}::{token}
+			token := string(k[len(prefix):])
+			keyCopy := make([]byte, len(k))
+			copy(keyCopy, k)
+
+			if err := sb.Delete([]byte(token)); err != nil {
+				return err
+			}
+			if err := sb.Delete(keyCopy); err != nil {
+				return err
+			}
+		}
+
+		// Cascade-delete API tokens for this user.
+		ab := tx.Bucket(bucketAPITokens)
+		aprefix := apiTokenUserIndexPrefix(id)
+		ac := ab.Cursor()
+		for k, _ := ac.Seek(aprefix); k != nil && bytes.HasPrefix(k, aprefix); k, _ = ac.Next() {
+			// Extract token ID from key: idx::user::{userID}::{tokenID}
+			tokenID := string(k[len(aprefix):])
+			keyCopy := make([]byte, len(k))
+			copy(keyCopy, k)
+
+			// Get the API token to find its hash index.
+			tv := ab.Get([]byte(tokenID))
+			if tv != nil {
+				var apiToken auth.APIToken
+				if err := json.Unmarshal(tv, &apiToken); err == nil {
+					_ = ab.Delete(apiTokenHashIndexKey(apiToken.TokenHash))
+				}
+			}
+
+			if err := ab.Delete([]byte(tokenID)); err != nil {
+				return err
+			}
+			if err := ab.Delete(keyCopy); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// ListUsers returns all users (excluding index keys).
+func (s *Store) ListUsers() ([]auth.User, error) {
+	var users []auth.User
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketUsers)
+		return b.ForEach(func(k, v []byte) error {
+			if isIndexKey(k) {
+				return nil
+			}
+			var user auth.User
+			if err := json.Unmarshal(v, &user); err != nil {
+				return nil // skip malformed records
+			}
+			users = append(users, user)
+			return nil
+		})
+	})
+	return users, err
+}
+
+// UserCount returns the number of user records (excluding index keys).
+func (s *Store) UserCount() (int, error) {
+	var count int
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketUsers)
+		c := b.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if !isIndexKey(k) {
+				count++
+			}
+		}
+		return nil
+	})
+	return count, err
+}
+
+// ============================================================
+// Session CRUD
+// ============================================================
+
+// CreateSession persists a session and its user index atomically.
+func (s *Store) CreateSession(session auth.Session) error {
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("marshal session: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketSessions)
+		if err := b.Put([]byte(session.Token), data); err != nil {
+			return err
+		}
+		return b.Put(sessionUserIndexKey(session.UserID, session.Token), []byte(""))
+	})
+}
+
+// GetSession retrieves a session by its token.
+func (s *Store) GetSession(token string) (*auth.Session, error) {
+	var session auth.Session
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketSessions)
+		v := b.Get([]byte(token))
+		if v == nil {
+			return fmt.Errorf("session not found")
+		}
+		return json.Unmarshal(v, &session)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+// DeleteSession removes a session and its user index entry.
+func (s *Store) DeleteSession(token string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketSessions)
+
+		// Get session to find userID for index cleanup.
+		v := b.Get([]byte(token))
+		if v == nil {
+			return nil // already gone — idempotent
+		}
+
+		var session auth.Session
+		if err := json.Unmarshal(v, &session); err != nil {
+			// Can't parse — still delete the primary key.
+			return b.Delete([]byte(token))
+		}
+
+		if err := b.Delete([]byte(token)); err != nil {
+			return err
+		}
+		return b.Delete(sessionUserIndexKey(session.UserID, token))
+	})
+}
+
+// DeleteSessionsForUser removes all sessions belonging to the given user.
+func (s *Store) DeleteSessionsForUser(userID string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketSessions)
+		prefix := sessionUserIndexPrefix(userID)
+		c := b.Cursor()
+
+		// Collect keys first — mutating during iteration is unsafe.
+		var tokens []string
+		var indexKeys [][]byte
+		for k, _ := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+			token := string(k[len(prefix):])
+			tokens = append(tokens, token)
+			keyCopy := make([]byte, len(k))
+			copy(keyCopy, k)
+			indexKeys = append(indexKeys, keyCopy)
+		}
+
+		for i, token := range tokens {
+			if err := b.Delete([]byte(token)); err != nil {
+				return err
+			}
+			if err := b.Delete(indexKeys[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// ListSessionsForUser returns all sessions belonging to the given user.
+func (s *Store) ListSessionsForUser(userID string) ([]auth.Session, error) {
+	var sessions []auth.Session
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketSessions)
+		prefix := sessionUserIndexPrefix(userID)
+		c := b.Cursor()
+
+		for k, _ := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+			token := string(k[len(prefix):])
+			v := b.Get([]byte(token))
+			if v == nil {
+				continue
+			}
+			var session auth.Session
+			if err := json.Unmarshal(v, &session); err != nil {
+				continue
+			}
+			sessions = append(sessions, session)
+		}
+		return nil
+	})
+	return sessions, err
+}
+
+// DeleteExpiredSessions removes all sessions whose ExpiresAt is in the past.
+// Returns the number of sessions deleted.
+func (s *Store) DeleteExpiredSessions() (int, error) {
+	var deleted int
+	now := time.Now().UTC()
+
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketSessions)
+		c := b.Cursor()
+
+		// Collect expired session keys and their user index keys.
+		type expiredEntry struct {
+			token    string
+			indexKey []byte
+		}
+		var expired []expiredEntry
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if isIndexKey(k) {
+				continue
+			}
+			var session auth.Session
+			if err := json.Unmarshal(v, &session); err != nil {
+				continue
+			}
+			if !session.ExpiresAt.IsZero() && session.ExpiresAt.Before(now) {
+				idxKey := sessionUserIndexKey(session.UserID, session.Token)
+				expired = append(expired, expiredEntry{
+					token:    string(k),
+					indexKey: idxKey,
+				})
+			}
+		}
+
+		for _, e := range expired {
+			if err := b.Delete([]byte(e.token)); err != nil {
+				return err
+			}
+			if err := b.Delete(e.indexKey); err != nil {
+				return err
+			}
+			deleted++
+		}
+		return nil
+	})
+	return deleted, err
+}
+
+// ============================================================
+// Role CRUD
+// ============================================================
+
+// GetRole retrieves a role by ID.
+func (s *Store) GetRole(id string) (*auth.Role, error) {
+	var role auth.Role
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketRoles)
+		v := b.Get([]byte(id))
+		if v == nil {
+			return fmt.Errorf("role %q not found", id)
+		}
+		return json.Unmarshal(v, &role)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &role, nil
+}
+
+// ListRoles returns all stored roles.
+func (s *Store) ListRoles() ([]auth.Role, error) {
+	var roles []auth.Role
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketRoles)
+		return b.ForEach(func(k, v []byte) error {
+			var role auth.Role
+			if err := json.Unmarshal(v, &role); err != nil {
+				return nil // skip malformed
+			}
+			roles = append(roles, role)
+			return nil
+		})
+	})
+	return roles, err
+}
+
+// SeedBuiltinRoles inserts the built-in roles if they don't already exist.
+func (s *Store) SeedBuiltinRoles() error {
+	roles := auth.BuiltinRoles()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketRoles)
+		for _, role := range roles {
+			if existing := b.Get([]byte(role.ID)); existing != nil {
+				continue // don't overwrite existing roles
+			}
+			data, err := json.Marshal(role)
+			if err != nil {
+				return fmt.Errorf("marshal role %q: %w", role.ID, err)
+			}
+			if err := b.Put([]byte(role.ID), data); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// ============================================================
+// API Token CRUD
+// ============================================================
+
+// CreateAPIToken persists an API token with hash and user indexes.
+func (s *Store) CreateAPIToken(token auth.APIToken) error {
+	data, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("marshal api token: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketAPITokens)
+
+		if err := b.Put([]byte(token.ID), data); err != nil {
+			return err
+		}
+		if err := b.Put(apiTokenHashIndexKey(token.TokenHash), []byte(token.ID)); err != nil {
+			return err
+		}
+		return b.Put(apiTokenUserIndexKey(token.UserID, token.ID), []byte(""))
+	})
+}
+
+// GetAPITokenByHash retrieves an API token by its SHA-256 hash.
+func (s *Store) GetAPITokenByHash(hash string) (*auth.APIToken, error) {
+	var token auth.APIToken
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketAPITokens)
+
+		idBytes := b.Get(apiTokenHashIndexKey(hash))
+		if idBytes == nil {
+			return fmt.Errorf("api token not found")
+		}
+
+		v := b.Get(idBytes)
+		if v == nil {
+			return fmt.Errorf("api token index orphan for hash %q", hash)
+		}
+		return json.Unmarshal(v, &token)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &token, nil
+}
+
+// DeleteAPIToken removes an API token and all its indexes.
+func (s *Store) DeleteAPIToken(id string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketAPITokens)
+
+		v := b.Get([]byte(id))
+		if v == nil {
+			return nil // already gone — idempotent
+		}
+
+		var token auth.APIToken
+		if err := json.Unmarshal(v, &token); err != nil {
+			// Can't parse — still delete the primary key.
+			return b.Delete([]byte(id))
+		}
+
+		if err := b.Delete([]byte(id)); err != nil {
+			return err
+		}
+		if err := b.Delete(apiTokenHashIndexKey(token.TokenHash)); err != nil {
+			return err
+		}
+		return b.Delete(apiTokenUserIndexKey(token.UserID, token.ID))
+	})
+}
+
+// ListAPITokensForUser returns all API tokens belonging to the given user.
+func (s *Store) ListAPITokensForUser(userID string) ([]auth.APIToken, error) {
+	var tokens []auth.APIToken
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketAPITokens)
+		prefix := apiTokenUserIndexPrefix(userID)
+		c := b.Cursor()
+
+		for k, _ := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+			tokenID := string(k[len(prefix):])
+			v := b.Get([]byte(tokenID))
+			if v == nil {
+				continue
+			}
+			var token auth.APIToken
+			if err := json.Unmarshal(v, &token); err != nil {
+				continue
+			}
+			tokens = append(tokens, token)
+		}
+		return nil
+	})
+	return tokens, err
+}

--- a/internal/store/bolt_auth_buckets.go
+++ b/internal/store/bolt_auth_buckets.go
@@ -1,0 +1,23 @@
+package store
+
+import bolt "go.etcd.io/bbolt"
+
+var (
+	bucketUsers     = []byte("users")
+	bucketSessions  = []byte("sessions")
+	bucketRoles     = []byte("roles")
+	bucketAPITokens = []byte("api_tokens")
+)
+
+// EnsureAuthBuckets creates the four auth-related BoltDB buckets if they
+// do not already exist. Call this after Open() to initialise auth storage.
+func (s *Store) EnsureAuthBuckets() error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		for _, b := range [][]byte{bucketUsers, bucketSessions, bucketRoles, bucketAPITokens} {
+			if _, err := tx.CreateBucketIfNotExists(b); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/internal/web/handlers_auth.go
+++ b/internal/web/handlers_auth.go
@@ -1,0 +1,622 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Will-Luck/Docker-Sentinel/internal/auth"
+)
+
+// authPageData extends template data with authentication context.
+type authPageData struct {
+	CurrentUser *auth.User `json:"-"`
+	AuthEnabled bool       `json:"-"`
+	CSRFToken   string     `json:"-"`
+}
+
+// getAuthData extracts authentication context from the request.
+func (s *Server) getAuthData(r *http.Request) authPageData {
+	rc := auth.GetRequestContext(r.Context())
+	var data authPageData
+	if rc != nil {
+		data.CurrentUser = rc.User
+		data.AuthEnabled = rc.AuthEnabled
+	}
+	if cookie, err := r.Cookie(auth.CSRFCookieName); err == nil {
+		data.CSRFToken = cookie.Value
+	}
+	return data
+}
+
+// handleLogin renders the login page.
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Auth != nil && !s.deps.Auth.AuthEnabled() {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+	// If already logged in, redirect to dashboard.
+	if token := auth.GetSessionToken(r); token != "" {
+		if rc := s.deps.Auth.ValidateSession(r.Context(), token); rc != nil {
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+			return
+		}
+	}
+	s.renderTemplate(w, "login.html", map[string]any{"Error": r.URL.Query().Get("error")})
+}
+
+// apiLogin processes login form submission.
+func (s *Server) apiLogin(w http.ResponseWriter, r *http.Request) {
+	var username, password string
+
+	ct := r.Header.Get("Content-Type")
+	if strings.Contains(ct, "application/json") {
+		var body struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		username = body.Username
+		password = body.Password
+	} else {
+		_ = r.ParseForm()
+		username = r.FormValue("username")
+		password = r.FormValue("password")
+	}
+
+	if username == "" || password == "" {
+		writeError(w, http.StatusBadRequest, "username and password required")
+		return
+	}
+
+	ip := r.RemoteAddr
+	session, user, err := s.deps.Auth.Login(r.Context(), username, password, ip, r.UserAgent())
+	if err != nil {
+		switch err {
+		case auth.ErrRateLimited:
+			writeError(w, http.StatusTooManyRequests, "too many login attempts, try again later")
+		case auth.ErrAccountLocked:
+			writeError(w, http.StatusForbidden, "account is temporarily locked")
+		default:
+			writeError(w, http.StatusUnauthorized, "invalid credentials")
+		}
+		return
+	}
+
+	auth.SetSessionCookie(w, session.Token, session.ExpiresAt, s.deps.Auth.CookieSecure)
+
+	s.logEvent("auth", "", "User "+user.Username+" logged in from "+ip)
+
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		writeJSON(w, http.StatusOK, map[string]string{"redirect": "/"})
+	} else {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	}
+}
+
+// handleSetup renders the first-run setup page.
+func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Auth == nil || !s.deps.Auth.NeedsSetup() {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+	s.renderTemplate(w, "setup.html", map[string]any{
+		"Token": r.URL.Query().Get("token"),
+	})
+}
+
+// apiSetup processes first-run setup form.
+func (s *Server) apiSetup(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Auth == nil || !s.deps.Auth.NeedsSetup() {
+		writeError(w, http.StatusConflict, "setup already complete")
+		return
+	}
+
+	// Verify bootstrap token.
+	_ = r.ParseForm()
+	token := r.FormValue("token")
+	if token == "" {
+		// Try JSON body.
+		var body struct {
+			Token    string `json:"token"`
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+			if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+				token = body.Token
+				if r.FormValue("username") == "" {
+					r.Form.Set("username", body.Username)
+					r.Form.Set("password", body.Password)
+				}
+			}
+		}
+	}
+
+	if s.bootstrapToken != "" && token != s.bootstrapToken {
+		writeError(w, http.StatusForbidden, "invalid setup token")
+		return
+	}
+
+	username := r.FormValue("username")
+	password := r.FormValue("password")
+	if username == "" || password == "" {
+		writeError(w, http.StatusBadRequest, "username and password required")
+		return
+	}
+
+	if err := auth.ValidatePassword(password); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to hash password")
+		return
+	}
+
+	userID, err := auth.GenerateUserID()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate user ID")
+		return
+	}
+
+	user := auth.User{
+		ID:           userID,
+		Username:     username,
+		PasswordHash: hash,
+		RoleID:       auth.RoleAdminID,
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}
+
+	// Atomic: create first user only if none exist.
+	if err := s.deps.Auth.Users.CreateFirstUser(user); err != nil {
+		if err == auth.ErrUsersExist {
+			writeError(w, http.StatusConflict, "setup already complete")
+		} else {
+			writeError(w, http.StatusInternalServerError, "failed to create admin user")
+		}
+		return
+	}
+
+	// Seed built-in roles.
+	_ = s.deps.Auth.Roles.SeedBuiltinRoles()
+
+	// Mark setup complete.
+	_ = s.deps.Auth.Settings.SaveSetting("auth_setup_complete", "true")
+
+	// Clear bootstrap token.
+	s.bootstrapToken = ""
+
+	// Create session for the new admin.
+	sessionToken, _ := auth.GenerateSessionToken()
+	session := auth.Session{
+		Token:     sessionToken,
+		UserID:    user.ID,
+		IP:        r.RemoteAddr,
+		UserAgent: r.UserAgent(),
+		CreatedAt: time.Now().UTC(),
+		ExpiresAt: time.Now().UTC().Add(s.deps.Auth.SessionExpiry),
+	}
+	_ = s.deps.Auth.Sessions.CreateSession(session)
+	auth.SetSessionCookie(w, sessionToken, session.ExpiresAt, s.deps.Auth.CookieSecure)
+
+	s.logEvent("auth", "", "Initial admin user "+username+" created via setup wizard")
+
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		writeJSON(w, http.StatusOK, map[string]string{"redirect": "/"})
+	} else {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	}
+}
+
+// handleLogout processes logout.
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	if token := auth.GetSessionToken(r); token != "" {
+		_ = s.deps.Auth.Logout(token)
+	}
+	auth.ClearSessionCookie(w, s.deps.Auth.CookieSecure)
+	http.Redirect(w, r, "/login", http.StatusSeeOther)
+}
+
+// handleAccount renders the My Account page.
+func (s *Server) handleAccount(w http.ResponseWriter, r *http.Request) {
+	ad := s.getAuthData(r)
+	if ad.CurrentUser == nil {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	sessions, _ := s.deps.Auth.Sessions.ListSessionsForUser(ad.CurrentUser.ID)
+	tokens, _ := s.deps.Auth.Tokens.ListAPITokensForUser(ad.CurrentUser.ID)
+
+	currentToken := auth.GetSessionToken(r)
+
+	s.renderTemplate(w, "account.html", map[string]any{
+		"CurrentUser":  ad.CurrentUser,
+		"AuthEnabled":  ad.AuthEnabled,
+		"CSRFToken":    ad.CSRFToken,
+		"Sessions":     sessions,
+		"Tokens":       tokens,
+		"CurrentToken": currentToken,
+		"QueueCount":   len(s.deps.Queue.List()),
+	})
+}
+
+// apiChangePassword changes the current user's password.
+func (s *Server) apiChangePassword(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	var body struct {
+		CurrentPassword string `json:"current_password"`
+		NewPassword     string `json:"new_password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if !auth.CheckPassword(rc.User.PasswordHash, body.CurrentPassword) {
+		writeError(w, http.StatusUnauthorized, "current password is incorrect")
+		return
+	}
+
+	if err := auth.ValidatePassword(body.NewPassword); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	hash, err := auth.HashPassword(body.NewPassword)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to hash password")
+		return
+	}
+
+	rc.User.PasswordHash = hash
+	rc.User.UpdatedAt = time.Now().UTC()
+	if err := s.deps.Auth.Users.UpdateUser(*rc.User); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update password")
+		return
+	}
+
+	s.logEvent("auth", "", "User "+rc.User.Username+" changed their password")
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// apiListSessions returns the current user's active sessions.
+func (s *Server) apiListSessions(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	sessions, err := s.deps.Auth.Sessions.ListSessionsForUser(rc.User.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list sessions")
+		return
+	}
+	writeJSON(w, http.StatusOK, sessions)
+}
+
+// apiRevokeSession revokes a specific session.
+func (s *Server) apiRevokeSession(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	token := r.PathValue("token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "session token required")
+		return
+	}
+
+	// Verify the session belongs to the current user.
+	session, err := s.deps.Auth.Sessions.GetSession(token)
+	if err != nil || session == nil || session.UserID != rc.User.ID {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	if err := s.deps.Auth.Sessions.DeleteSession(token); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to revoke session")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// apiRevokeAllSessions revokes all sessions except the current one.
+func (s *Server) apiRevokeAllSessions(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	currentToken := auth.GetSessionToken(r)
+	sessions, _ := s.deps.Auth.Sessions.ListSessionsForUser(rc.User.ID)
+	for _, sess := range sessions {
+		if sess.Token != currentToken {
+			_ = s.deps.Auth.Sessions.DeleteSession(sess.Token)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// apiCreateToken creates a new API bearer token.
+func (s *Server) apiCreateToken(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
+		writeError(w, http.StatusBadRequest, "token name required")
+		return
+	}
+
+	plaintext, hash, err := auth.GenerateAPIToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+	tokenID, err := auth.GenerateTokenID()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token ID")
+		return
+	}
+
+	apiToken := auth.APIToken{
+		ID:        tokenID,
+		Name:      body.Name,
+		TokenHash: hash,
+		UserID:    rc.User.ID,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	if err := s.deps.Auth.Tokens.CreateAPIToken(apiToken); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create token")
+		return
+	}
+
+	s.logEvent("auth", "", "API token "+body.Name+" created by "+rc.User.Username)
+
+	writeJSON(w, http.StatusCreated, map[string]string{
+		"id":    tokenID,
+		"name":  body.Name,
+		"token": plaintext,
+	})
+}
+
+// apiDeleteToken deletes an API token.
+func (s *Server) apiDeleteToken(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "token ID required")
+		return
+	}
+
+	// Users can only delete their own tokens (admin can delete any via user management).
+	tokens, _ := s.deps.Auth.Tokens.ListAPITokensForUser(rc.User.ID)
+	found := false
+	for _, t := range tokens {
+		if t.ID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "token not found")
+		return
+	}
+
+	if err := s.deps.Auth.Tokens.DeleteAPIToken(id); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete token")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// apiListUsers returns all users (admin only).
+func (s *Server) apiListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := s.deps.Auth.Users.ListUsers()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list users")
+		return
+	}
+
+	// Strip password hashes from response.
+	type safeUser struct {
+		ID        string    `json:"id"`
+		Username  string    `json:"username"`
+		RoleID    string    `json:"role_id"`
+		CreatedAt time.Time `json:"created_at"`
+		Locked    bool      `json:"locked"`
+	}
+	result := make([]safeUser, len(users))
+	for i, u := range users {
+		result[i] = safeUser{
+			ID:        u.ID,
+			Username:  u.Username,
+			RoleID:    u.RoleID,
+			CreatedAt: u.CreatedAt,
+			Locked:    u.Locked,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// apiCreateUser creates a new user (admin only).
+func (s *Server) apiCreateUser(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		RoleID   string `json:"role_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if body.Username == "" || body.Password == "" {
+		writeError(w, http.StatusBadRequest, "username and password required")
+		return
+	}
+
+	// Validate role.
+	switch body.RoleID {
+	case auth.RoleAdminID, auth.RoleOperatorID, auth.RoleViewerID:
+		// valid
+	default:
+		writeError(w, http.StatusBadRequest, "invalid role")
+		return
+	}
+
+	if err := auth.ValidatePassword(body.Password); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	hash, err := auth.HashPassword(body.Password)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to hash password")
+		return
+	}
+
+	userID, err := auth.GenerateUserID()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate user ID")
+		return
+	}
+
+	user := auth.User{
+		ID:           userID,
+		Username:     body.Username,
+		PasswordHash: hash,
+		RoleID:       body.RoleID,
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}
+
+	if err := s.deps.Auth.Users.CreateUser(user); err != nil {
+		writeError(w, http.StatusConflict, "username already exists")
+		return
+	}
+
+	rc := auth.GetRequestContext(r.Context())
+	if rc != nil && rc.User != nil {
+		s.logEvent("auth", "", "User "+body.Username+" created by "+rc.User.Username+" (role: "+body.RoleID+")")
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"id": userID, "username": body.Username})
+}
+
+// apiDeleteUser deletes a user (admin only).
+func (s *Server) apiDeleteUser(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "user ID required")
+		return
+	}
+
+	// Prevent self-deletion.
+	if id == rc.User.ID {
+		writeError(w, http.StatusBadRequest, "cannot delete your own account")
+		return
+	}
+
+	target, err := s.deps.Auth.Users.GetUser(id)
+	if err != nil || target == nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+
+	if err := s.deps.Auth.Users.DeleteUser(id); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete user")
+		return
+	}
+
+	s.logEvent("auth", "", "User "+target.Username+" deleted by "+rc.User.Username)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// apiAuthSettings handles auth toggle (admin only).
+func (s *Server) apiAuthSettings(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		AuthEnabled bool `json:"auth_enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	val := "true"
+	if !body.AuthEnabled {
+		val = "false"
+	}
+
+	if err := s.deps.Auth.Settings.SaveSetting("auth_enabled", val); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save setting")
+		return
+	}
+
+	rc := auth.GetRequestContext(r.Context())
+	if rc != nil && rc.User != nil {
+		action := "enabled"
+		if !body.AuthEnabled {
+			action = "disabled"
+		}
+		s.logEvent("auth", "", "Authentication "+action+" by "+rc.User.Username)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// apiGetMe returns the current user's information.
+func (s *Server) apiGetMe(w http.ResponseWriter, r *http.Request) {
+	rc := auth.GetRequestContext(r.Context())
+	if rc == nil || rc.User == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":           rc.User.ID,
+		"username":     rc.User.Username,
+		"role_id":      rc.User.RoleID,
+		"permissions":  rc.Permissions,
+		"auth_enabled": rc.AuthEnabled,
+	})
+}

--- a/internal/web/static/account.html
+++ b/internal/web/static/account.html
@@ -1,0 +1,149 @@
+{{define "account.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Account — Docker-Sentinel</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+</head>
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <nav class="nav">
+        <a href="/" class="nav-brand">
+            <span class="nav-logo">S</span>
+            <span class="nav-brand-text">Sentinel</span>
+        </a>
+        <div class="nav-links">
+            <a href="/" class="nav-link">Dashboard</a>
+            <a href="/queue" class="nav-link">
+                Queue
+                {{if .QueueCount}}<span class="nav-badge">{{.QueueCount}}</span>{{end}}
+            </a>
+            <a href="/history" class="nav-link">History</a>
+            <a href="/logs" class="nav-link">Logs</a>
+            <a href="/settings" class="nav-link">Settings</a>
+        </div>
+        {{if .AuthEnabled}}
+        <div class="nav-user" style="margin-left:auto;display:flex;align-items:center;gap:var(--sp-3)">
+            <span style="font-size:0.8rem;color:var(--fg-secondary)">{{.CurrentUser.Username}}</span>
+            <a href="/account" class="nav-link active" aria-current="page" style="height:auto;padding:0 var(--sp-2);border-bottom:none;font-size:0.8rem;color:var(--accent)">Account</a>
+            <a href="/logout" class="nav-link" style="height:auto;padding:0 var(--sp-2);border-bottom:none;font-size:0.8rem">Logout</a>
+        </div>
+        {{end}}
+    </nav>
+
+    <main class="main-content" id="main-content">
+        <div class="page-header">
+            <div>
+                <h1>My Account</h1>
+                <p class="subtitle">Manage your sessions and API tokens</p>
+            </div>
+        </div>
+
+        <!-- Change Password -->
+        <div class="card" style="margin-bottom:var(--sp-4)">
+            <div class="card-header"><h2>Change Password</h2></div>
+            <div class="card-body">
+                <form id="change-password-form" class="settings-grid" style="max-width:400px">
+                    <div style="margin-bottom:var(--sp-3)">
+                        <label style="display:block;font-size:0.875rem;font-weight:500;color:var(--fg-secondary);margin-bottom:var(--sp-1)" for="current-password">Current Password</label>
+                        <input class="setting-input" type="password" id="current-password" autocomplete="current-password" required style="width:100%">
+                    </div>
+                    <div style="margin-bottom:var(--sp-3)">
+                        <label style="display:block;font-size:0.875rem;font-weight:500;color:var(--fg-secondary);margin-bottom:var(--sp-1)" for="new-password">New Password</label>
+                        <input class="setting-input" type="password" id="new-password" autocomplete="new-password" required minlength="8" style="width:100%">
+                    </div>
+                    <button class="btn btn-success" type="submit">Update Password</button>
+                </form>
+            </div>
+        </div>
+
+        <!-- Active Sessions -->
+        <div class="card" style="margin-bottom:var(--sp-4)">
+            <div class="card-header"><h2>Active Sessions</h2></div>
+            <div class="card-body">
+                <div class="table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>IP</th>
+                                <th>User Agent</th>
+                                <th>Created</th>
+                                <th>Expires</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody id="session-list">
+                            {{range .Sessions}}
+                            <tr>
+                                <td class="mono">{{.IP}}</td>
+                                <td style="max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="{{.UserAgent}}">{{.UserAgent}}</td>
+                                <td>{{fmtTimeAgo .CreatedAt}}</td>
+                                <td>{{fmtTimeAgo .ExpiresAt}}</td>
+                                <td><button class="btn btn-error" onclick="revokeSession('{{.Token}}')">Revoke</button></td>
+                            </tr>
+                            {{else}}
+                            <tr><td colspan="5" style="text-align:center;color:var(--fg-secondary)">No active sessions</td></tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                </div>
+                <div style="margin-top:var(--sp-3)">
+                    <button class="btn btn-error" onclick="revokeAllSessions()">Revoke All Other Sessions</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- API Tokens -->
+        <div class="card">
+            <div class="card-header"><h2>API Tokens</h2></div>
+            <div class="card-body">
+                <div class="table-wrap">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Created</th>
+                                <th>Last Used</th>
+                                <th>Expires</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody id="token-list">
+                            {{range .APITokens}}
+                            <tr>
+                                <td>{{.Name}}</td>
+                                <td>{{fmtTimeAgo .CreatedAt}}</td>
+                                <td>{{if .LastUsedAt.IsZero}}Never{{else}}{{fmtTimeAgo .LastUsedAt}}{{end}}</td>
+                                <td>{{if .ExpiresAt.IsZero}}Never{{else}}{{fmtTimeAgo .ExpiresAt}}{{end}}</td>
+                                <td><button class="btn btn-error" onclick="deleteToken('{{.ID}}')">Delete</button></td>
+                            </tr>
+                            {{else}}
+                            <tr><td colspan="5" style="text-align:center;color:var(--fg-secondary)">No API tokens</td></tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                </div>
+                <div style="margin-top:var(--sp-3);display:flex;gap:var(--sp-2);align-items:center">
+                    <input type="text" id="new-token-name" placeholder="Token name" class="setting-input" style="max-width:200px">
+                    <button class="btn btn-success" onclick="createToken()">Create Token</button>
+                </div>
+                <div id="new-token-display" style="display:none;margin-top:var(--sp-3);padding:var(--sp-3);background:var(--warning-bg);border:1px solid var(--warning);border-radius:var(--radius)">
+                    <strong>Copy this token now — it will not be shown again:</strong>
+                    <div class="mono" id="new-token-value" style="margin-top:var(--sp-2);word-break:break-all;cursor:pointer" onclick="copyToken()" title="Click to copy"></div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <div id="toast-container" class="toast-container"></div>
+    <script src="/static/app.js"></script>
+    <script src="/static/auth.js"></script>
+</body>
+</html>
+{{end}}

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -4,6 +4,44 @@
    ============================================================ */
 
 /* ------------------------------------------------------------
+   0. CSRF Protection — auto-inject X-CSRF-Token on mutating requests
+   ------------------------------------------------------------ */
+
+(function () {
+    var originalFetch = window.fetch;
+
+    function getCSRFToken() {
+        var match = document.cookie.match(/(^|;\s*)sentinel_csrf=([^;]+)/);
+        return match ? match[2] : "";
+    }
+
+    window.fetch = function (url, opts) {
+        opts = opts || {};
+        var method = (opts.method || "GET").toUpperCase();
+        // Only inject CSRF on state-changing methods for same-origin requests.
+        if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
+            var token = getCSRFToken();
+            if (token) {
+                opts.headers = opts.headers || {};
+                // Support both Headers object and plain object.
+                if (typeof opts.headers.set === "function") {
+                    opts.headers.set("X-CSRF-Token", token);
+                } else {
+                    opts.headers["X-CSRF-Token"] = token;
+                }
+            }
+        }
+        return originalFetch.call(window, url, opts).then(function (resp) {
+            // Auto-redirect to login on 401 (session expired).
+            if (resp.status === 401 && url.indexOf("/api/auth/me") === -1) {
+                window.location.href = "/login";
+            }
+            return resp;
+        });
+    };
+})();
+
+/* ------------------------------------------------------------
    1. Theme System
    ------------------------------------------------------------ */
 

--- a/internal/web/static/auth.js
+++ b/internal/web/static/auth.js
@@ -1,0 +1,406 @@
+/* ============================================================
+   Docker-Sentinel Auth — Client-side JavaScript
+   ES5-compatible (no let/const/arrow functions)
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   1. CSRF Helper
+   ------------------------------------------------------------ */
+
+function getCSRFToken() {
+    var cookies = document.cookie.split(";");
+    for (var i = 0; i < cookies.length; i++) {
+        var cookie = cookies[i].replace(/^\s+/, "");
+        if (cookie.indexOf("sentinel_csrf=") === 0) {
+            return cookie.substring("sentinel_csrf=".length);
+        }
+    }
+    return "";
+}
+
+function authFetch(url, options) {
+    if (!options) options = {};
+    if (!options.headers) options.headers = {};
+
+    // Add CSRF token for mutating requests.
+    var method = (options.method || "GET").toUpperCase();
+    if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
+        options.headers["X-CSRF-Token"] = getCSRFToken();
+    }
+
+    return fetch(url, options).then(function(resp) {
+        // Handle 401 — redirect to login.
+        if (resp.status === 401) {
+            window.location.href = "/login";
+            return Promise.reject(new Error("Unauthorized"));
+        }
+        return resp;
+    });
+}
+
+/* ------------------------------------------------------------
+   2. Change Password
+   ------------------------------------------------------------ */
+
+function initChangePassword() {
+    var form = document.getElementById("change-password-form");
+    if (!form) return;
+
+    form.addEventListener("submit", function(e) {
+        e.preventDefault();
+        var currentPw = document.getElementById("current-password").value;
+        var newPw = document.getElementById("new-password").value;
+
+        authFetch("/api/auth/change-password", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ current_password: currentPw, new_password: newPw })
+        })
+            .then(function(resp) {
+                return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+            })
+            .then(function(result) {
+                if (result.ok) {
+                    showToast("Password updated", "success");
+                    form.reset();
+                } else {
+                    showToast(result.data.error || "Failed to update password", "error");
+                }
+            })
+            .catch(function(err) {
+                if (err.message !== "Unauthorized") {
+                    showToast("Network error", "error");
+                }
+            });
+    });
+}
+
+/* ------------------------------------------------------------
+   3. Session Management
+   ------------------------------------------------------------ */
+
+function revokeSession(token) {
+    authFetch("/api/auth/sessions/" + encodeURIComponent(token), {
+        method: "DELETE"
+    })
+        .then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+        })
+        .then(function(result) {
+            if (result.ok) {
+                showToast("Session revoked", "success");
+                window.location.reload();
+            } else {
+                showToast(result.data.error || "Failed to revoke session", "error");
+            }
+        })
+        .catch(function(err) {
+            if (err.message !== "Unauthorized") {
+                showToast("Network error", "error");
+            }
+        });
+}
+
+function revokeAllSessions() {
+    authFetch("/api/auth/sessions", {
+        method: "DELETE"
+    })
+        .then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+        })
+        .then(function(result) {
+            if (result.ok) {
+                showToast("All other sessions revoked", "success");
+                window.location.reload();
+            } else {
+                showToast(result.data.error || "Failed to revoke sessions", "error");
+            }
+        })
+        .catch(function(err) {
+            if (err.message !== "Unauthorized") {
+                showToast("Network error", "error");
+            }
+        });
+}
+
+/* ------------------------------------------------------------
+   4. API Token Management
+   ------------------------------------------------------------ */
+
+function createToken() {
+    var nameInput = document.getElementById("new-token-name");
+    var name = nameInput ? nameInput.value : "";
+    if (!name) {
+        showToast("Enter a token name", "error");
+        return;
+    }
+
+    authFetch("/api/auth/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name })
+    })
+        .then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+        })
+        .then(function(result) {
+            if (result.ok) {
+                showToast("Token created", "success");
+                var display = document.getElementById("new-token-display");
+                var value = document.getElementById("new-token-value");
+                if (display && value) {
+                    display.style.display = "";
+                    value.textContent = result.data.token;
+                }
+                if (nameInput) nameInput.value = "";
+                // Reload after a delay to show the new token in the list.
+                setTimeout(function() { window.location.reload(); }, 5000);
+            } else {
+                showToast(result.data.error || "Failed to create token", "error");
+            }
+        })
+        .catch(function(err) {
+            if (err.message !== "Unauthorized") {
+                showToast("Network error", "error");
+            }
+        });
+}
+
+function deleteToken(id) {
+    authFetch("/api/auth/tokens/" + encodeURIComponent(id), {
+        method: "DELETE"
+    })
+        .then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+        })
+        .then(function(result) {
+            if (result.ok) {
+                showToast("Token deleted", "success");
+                window.location.reload();
+            } else {
+                showToast(result.data.error || "Failed to delete token", "error");
+            }
+        })
+        .catch(function(err) {
+            if (err.message !== "Unauthorized") {
+                showToast("Network error", "error");
+            }
+        });
+}
+
+function copyToken() {
+    var el = document.getElementById("new-token-value");
+    if (!el) return;
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(el.textContent).then(function() {
+            showToast("Copied to clipboard", "info");
+        });
+    }
+}
+
+/* ------------------------------------------------------------
+   5. User Management (settings page, admin only)
+   ------------------------------------------------------------ */
+
+function loadUsers() {
+    var container = document.getElementById("user-list");
+    if (!container) return;
+
+    authFetch("/api/auth/users")
+        .then(function(resp) { return resp.json(); })
+        .then(function(users) {
+            if (!Array.isArray(users)) return;
+
+            // Build rows using safe DOM methods.
+            while (container.firstChild) container.removeChild(container.firstChild);
+
+            for (var i = 0; i < users.length; i++) {
+                var u = users[i];
+                var tr = document.createElement("tr");
+
+                var tdName = document.createElement("td");
+                tdName.textContent = u.username;
+                tr.appendChild(tdName);
+
+                var tdRole = document.createElement("td");
+                var roleBadge = document.createElement("span");
+                roleBadge.className = "badge badge-info";
+                roleBadge.textContent = u.role_id;
+                tdRole.appendChild(roleBadge);
+                tr.appendChild(tdRole);
+
+                var tdStatus = document.createElement("td");
+                var statusBadge = document.createElement("span");
+                if (u.locked) {
+                    statusBadge.className = "badge badge-error";
+                    statusBadge.textContent = "Locked";
+                } else {
+                    statusBadge.className = "badge badge-success";
+                    statusBadge.textContent = "Active";
+                }
+                tdStatus.appendChild(statusBadge);
+                tr.appendChild(tdStatus);
+
+                var tdActions = document.createElement("td");
+                var delBtn = document.createElement("button");
+                delBtn.className = "btn btn-error";
+                delBtn.textContent = "Delete";
+                delBtn.setAttribute("data-user-id", u.id);
+                delBtn.addEventListener("click", function() {
+                    deleteUser(this.getAttribute("data-user-id"));
+                });
+                tdActions.appendChild(delBtn);
+                tr.appendChild(tdActions);
+
+                container.appendChild(tr);
+            }
+        })
+        .catch(function() {});
+}
+
+function createUser() {
+    var username = document.getElementById("new-user-username");
+    var password = document.getElementById("new-user-password");
+    var role = document.getElementById("new-user-role");
+    if (!username || !password || !role) return;
+
+    authFetch("/api/auth/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            username: username.value,
+            password: password.value,
+            role_id: role.value
+        })
+    })
+        .then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+        })
+        .then(function(result) {
+            if (result.ok) {
+                showToast("User created", "success");
+                username.value = "";
+                password.value = "";
+                loadUsers();
+            } else {
+                showToast(result.data.error || "Failed to create user", "error");
+            }
+        })
+        .catch(function(err) {
+            if (err.message !== "Unauthorized") {
+                showToast("Network error", "error");
+            }
+        });
+}
+
+function deleteUser(id) {
+    authFetch("/api/auth/users/" + encodeURIComponent(id), {
+        method: "DELETE"
+    })
+        .then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+        })
+        .then(function(result) {
+            if (result.ok) {
+                showToast("User deleted", "success");
+                loadUsers();
+            } else {
+                showToast(result.data.error || "Failed to delete user", "error");
+            }
+        })
+        .catch(function(err) {
+            if (err.message !== "Unauthorized") {
+                showToast("Network error", "error");
+            }
+        });
+}
+
+function confirmAuthToggle(checkbox) {
+    if (!checkbox.checked) {
+        var confirmed = window.confirm(
+            "Disable authentication?\n\n" +
+            "All endpoints will be accessible without login. " +
+            "This is intended for trusted LAN usage only."
+        );
+        if (!confirmed) {
+            checkbox.checked = true;
+            return;
+        }
+    }
+    toggleAuth(checkbox.checked);
+}
+
+function toggleAuth(enabled) {
+    authFetch("/api/auth/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auth_enabled: enabled })
+    })
+        .then(function(resp) {
+            return resp.json().then(function(data) { return { ok: resp.ok, data: data }; });
+        })
+        .then(function(result) {
+            if (result.ok) {
+                showToast(enabled ? "Authentication enabled" : "Authentication disabled", "success");
+                window.location.reload();
+            } else {
+                showToast(result.data.error || "Failed to toggle auth", "error");
+            }
+        })
+        .catch(function(err) {
+            if (err.message !== "Unauthorized") {
+                showToast("Network error", "error");
+            }
+        });
+}
+
+/* ------------------------------------------------------------
+   6. Nav User Dropdown
+   ------------------------------------------------------------ */
+
+function toggleUserDropdown(e) {
+    e.stopPropagation();
+    var dropdown = document.getElementById("user-dropdown");
+    if (!dropdown) return;
+    var btn = e.currentTarget;
+    var isOpen = dropdown.classList.contains("open");
+    if (isOpen) {
+        dropdown.classList.remove("open");
+        btn.setAttribute("aria-expanded", "false");
+    } else {
+        dropdown.classList.add("open");
+        btn.setAttribute("aria-expanded", "true");
+    }
+}
+
+function closeUserDropdown() {
+    var dropdown = document.getElementById("user-dropdown");
+    if (!dropdown) return;
+    dropdown.classList.remove("open");
+    var btn = dropdown.parentElement ? dropdown.parentElement.querySelector(".nav-user-btn") : null;
+    if (btn) btn.setAttribute("aria-expanded", "false");
+}
+
+/* ------------------------------------------------------------
+   7. Init
+   ------------------------------------------------------------ */
+
+document.addEventListener("DOMContentLoaded", function() {
+    initChangePassword();
+    loadUsers();
+
+    // Close user dropdown when clicking outside.
+    document.addEventListener("click", function(e) {
+        var navUser = document.querySelector(".nav-user");
+        if (navUser && !navUser.contains(e.target)) {
+            closeUserDropdown();
+        }
+    });
+
+    // Close user dropdown on Escape key.
+    document.addEventListener("keydown", function(e) {
+        if (e.key === "Escape" || e.keyCode === 27) {
+            closeUserDropdown();
+        }
+    });
+});

--- a/internal/web/static/container.html
+++ b/internal/web/static/container.html
@@ -29,6 +29,25 @@
             <span id="sse-indicator" class="status-dot disconnected"></span>
             <span id="sse-label" class="nav-status-text">Disconnected</span>
         </div>
+        {{if .AuthEnabled}}{{if .CurrentUser}}
+        <div class="nav-user">
+            <button class="nav-user-btn" onclick="toggleUserDropdown(event)" aria-haspopup="true" aria-expanded="false">
+                <span>{{.CurrentUser.Username}}</span>
+                <span class="nav-user-role">{{.CurrentUser.RoleID}}</span>
+                <span class="nav-user-chevron">&#9662;</span>
+            </button>
+            <div class="nav-user-dropdown" id="user-dropdown">
+                <a href="/account">My Account</a>
+                <div class="dropdown-divider"></div>
+                <form method="POST" action="/logout" style="margin:0">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+                    <button type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{end}}{{else}}
+        <div class="nav-auth-off">Auth: Off</div>
+        {{end}}
     </nav>
 
     <main class="main-content" id="main-content">
@@ -169,6 +188,7 @@
 
     <div id="toast-container" class="toast-container"></div>
     <script src="/static/app.js"></script>
+    <script src="/static/auth.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/static/history.html
+++ b/internal/web/static/history.html
@@ -32,6 +32,25 @@
             <span id="sse-indicator" class="status-dot disconnected"></span>
             <span id="sse-label" class="nav-status-text">Disconnected</span>
         </div>
+        {{if .AuthEnabled}}{{if .CurrentUser}}
+        <div class="nav-user">
+            <button class="nav-user-btn" onclick="toggleUserDropdown(event)" aria-haspopup="true" aria-expanded="false">
+                <span>{{.CurrentUser.Username}}</span>
+                <span class="nav-user-role">{{.CurrentUser.RoleID}}</span>
+                <span class="nav-user-chevron">&#9662;</span>
+            </button>
+            <div class="nav-user-dropdown" id="user-dropdown">
+                <a href="/account">My Account</a>
+                <div class="dropdown-divider"></div>
+                <form method="POST" action="/logout" style="margin:0">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+                    <button type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{end}}{{else}}
+        <div class="nav-auth-off">Auth: Off</div>
+        {{end}}
     </nav>
 
     <main class="main-content" id="main-content">
@@ -118,6 +137,7 @@
 
     <div id="toast-container" class="toast-container"></div>
     <script src="/static/app.js"></script>
+    <script src="/static/auth.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -32,6 +32,25 @@
             <span id="sse-indicator" class="status-dot disconnected"></span>
             <span id="sse-label" class="nav-status-text">Disconnected</span>
         </div>
+        {{if .AuthEnabled}}{{if .CurrentUser}}
+        <div class="nav-user">
+            <button class="nav-user-btn" onclick="toggleUserDropdown(event)" aria-haspopup="true" aria-expanded="false">
+                <span>{{.CurrentUser.Username}}</span>
+                <span class="nav-user-role">{{.CurrentUser.RoleID}}</span>
+                <span class="nav-user-chevron">&#9662;</span>
+            </button>
+            <div class="nav-user-dropdown" id="user-dropdown">
+                <a href="/account">My Account</a>
+                <div class="dropdown-divider"></div>
+                <form method="POST" action="/logout" style="margin:0">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+                    <button type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{end}}{{else}}
+        <div class="nav-auth-off">Auth: Off</div>
+        {{end}}
     </nav>
 
     <main class="main-content" id="main-content">
@@ -159,6 +178,7 @@
 
     <div id="toast-container" class="toast-container"></div>
     <script src="/static/app.js"></script>
+    <script src="/static/auth.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/static/login.html
+++ b/internal/web/static/login.html
@@ -1,0 +1,139 @@
+{{define "login.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login — Docker-Sentinel</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <style>
+        .login-wrap {
+            display: flex;
+            min-height: 100vh;
+            align-items: center;
+            justify-content: center;
+            padding: var(--sp-4);
+            background: var(--bg-body);
+        }
+        .login-card {
+            width: 100%;
+            max-width: 400px;
+            background: var(--bg-surface);
+            border-radius: var(--radius-lg);
+            border: 1px solid var(--border);
+            padding: var(--sp-8);
+            box-shadow: var(--shadow-md);
+        }
+        .login-logo {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: var(--sp-3);
+            margin-bottom: var(--sp-6);
+        }
+        .login-logo .nav-logo {
+            width: 40px;
+            height: 40px;
+            font-size: 1.2rem;
+        }
+        .login-logo-text {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--fg-primary);
+        }
+        .login-form {
+            display: flex;
+            flex-direction: column;
+            gap: var(--sp-4);
+        }
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: var(--sp-1);
+        }
+        .form-label {
+            font-size: 0.875rem;
+            font-weight: 500;
+            color: var(--fg-secondary);
+        }
+        .form-input {
+            padding: 10px 14px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            background: var(--bg-input);
+            color: var(--fg-primary);
+            font-size: 0.95rem;
+            font-family: inherit;
+            outline: none;
+            transition: border-color 150ms var(--md-motion-standard);
+        }
+        .form-input:focus {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+        }
+        .login-error {
+            padding: 10px 14px;
+            border-radius: var(--radius);
+            background: var(--error-bg);
+            color: var(--error-fg);
+            font-size: 0.875rem;
+            border: 1px solid var(--error);
+            margin-bottom: var(--sp-4);
+        }
+        .login-btn {
+            padding: 12px;
+            font-size: 1rem;
+            font-weight: 500;
+            border: none;
+            border-radius: var(--radius);
+            background: var(--accent);
+            color: var(--md-on-primary);
+            cursor: pointer;
+            transition: opacity 150ms var(--md-motion-standard);
+        }
+        .login-btn:hover { opacity: 0.9; }
+        .login-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    </style>
+</head>
+<body>
+    <div class="login-wrap">
+        <div class="login-card">
+            <div class="login-logo">
+                <span class="nav-logo">S</span>
+                <span class="login-logo-text">Sentinel</span>
+            </div>
+
+            {{if .Error}}
+            <div class="login-error">{{.Error}}</div>
+            {{end}}
+
+            <form class="login-form" method="POST" action="/login" id="login-form">
+                <div class="form-group">
+                    <label class="form-label" for="username">Username</label>
+                    <input class="form-input" type="text" id="username" name="username" autocomplete="username" autofocus required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="password">Password</label>
+                    <input class="form-input" type="password" id="password" name="password" autocomplete="current-password" required>
+                </div>
+                <button class="login-btn" type="submit">Sign In</button>
+            </form>
+        </div>
+    </div>
+    <script>
+        // Focus management: if there is an error, focus the username field.
+        (function() {
+            var err = document.querySelector('.login-error');
+            if (err) {
+                var input = document.getElementById('username');
+                if (input) input.focus();
+            }
+        })();
+    </script>
+</body>
+</html>
+{{end}}

--- a/internal/web/static/logs.html
+++ b/internal/web/static/logs.html
@@ -32,6 +32,25 @@
             <span id="sse-indicator" class="status-dot disconnected"></span>
             <span id="sse-label" class="nav-status-text">Disconnected</span>
         </div>
+        {{if .AuthEnabled}}{{if .CurrentUser}}
+        <div class="nav-user">
+            <button class="nav-user-btn" onclick="toggleUserDropdown(event)" aria-haspopup="true" aria-expanded="false">
+                <span>{{.CurrentUser.Username}}</span>
+                <span class="nav-user-role">{{.CurrentUser.RoleID}}</span>
+                <span class="nav-user-chevron">&#9662;</span>
+            </button>
+            <div class="nav-user-dropdown" id="user-dropdown">
+                <a href="/account">My Account</a>
+                <div class="dropdown-divider"></div>
+                <form method="POST" action="/logout" style="margin:0">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+                    <button type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{end}}{{else}}
+        <div class="nav-auth-off">Auth: Off</div>
+        {{end}}
     </nav>
 
     <main class="main-content" id="main-content">
@@ -78,6 +97,7 @@
 
     <div id="toast-container" class="toast-container"></div>
     <script src="/static/app.js"></script>
+    <script src="/static/auth.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/static/queue.html
+++ b/internal/web/static/queue.html
@@ -32,6 +32,25 @@
             <span id="sse-indicator" class="status-dot disconnected"></span>
             <span id="sse-label" class="nav-status-text">Disconnected</span>
         </div>
+        {{if .AuthEnabled}}{{if .CurrentUser}}
+        <div class="nav-user">
+            <button class="nav-user-btn" onclick="toggleUserDropdown(event)" aria-haspopup="true" aria-expanded="false">
+                <span>{{.CurrentUser.Username}}</span>
+                <span class="nav-user-role">{{.CurrentUser.RoleID}}</span>
+                <span class="nav-user-chevron">&#9662;</span>
+            </button>
+            <div class="nav-user-dropdown" id="user-dropdown">
+                <a href="/account">My Account</a>
+                <div class="dropdown-divider"></div>
+                <form method="POST" action="/logout" style="margin:0">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+                    <button type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{end}}{{else}}
+        <div class="nav-auth-off">Auth: Off</div>
+        {{end}}
     </nav>
 
     <main class="main-content" id="main-content">
@@ -122,6 +141,7 @@
 
     <div id="toast-container" class="toast-container"></div>
     <script src="/static/app.js"></script>
+    <script src="/static/auth.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/static/settings.html
+++ b/internal/web/static/settings.html
@@ -32,6 +32,25 @@
             <span id="sse-indicator" class="status-dot disconnected"></span>
             <span id="sse-label" class="nav-status-text">Disconnected</span>
         </div>
+        {{if .AuthEnabled}}{{if .CurrentUser}}
+        <div class="nav-user">
+            <button class="nav-user-btn" onclick="toggleUserDropdown(event)" aria-haspopup="true" aria-expanded="false">
+                <span>{{.CurrentUser.Username}}</span>
+                <span class="nav-user-role">{{.CurrentUser.RoleID}}</span>
+                <span class="nav-user-chevron">&#9662;</span>
+            </button>
+            <div class="nav-user-dropdown" id="user-dropdown">
+                <a href="/account">My Account</a>
+                <div class="dropdown-divider"></div>
+                <form method="POST" action="/logout" style="margin:0">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+                    <button type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+        {{end}}{{else}}
+        <div class="nav-auth-off">Auth: Off</div>
+        {{end}}
     </nav>
 
     <main class="main-content" id="main-content">
@@ -46,6 +65,9 @@
             <button class="tab-btn active" role="tab" aria-selected="true" aria-controls="tab-general" data-tab="general">General</button>
             <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-notifications" data-tab="notifications">Notifications</button>
             <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-appearance" data-tab="appearance">Appearance</button>
+            {{if .AuthEnabled}}{{if .CurrentUser}}{{if eq .CurrentUser.RoleID "admin"}}
+            <button class="tab-btn" role="tab" aria-selected="false" aria-controls="tab-security" data-tab="security">Security</button>
+            {{end}}{{end}}{{end}}
         </div>
 
         <!-- General tab -->
@@ -226,10 +248,86 @@
                 </div>
             </div>
         </div>
+
+        <!-- Security tab (admin only) -->
+        {{if .AuthEnabled}}{{if .CurrentUser}}{{if eq .CurrentUser.RoleID "admin"}}
+        <div class="tab-panel" id="tab-security" role="tabpanel">
+            <div class="settings-grid">
+                <div class="card">
+                    <div class="card-header"><h2>Authentication</h2></div>
+                    <div class="card-body">
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Authentication</div>
+                                <div class="setting-desc">When disabled, all endpoints are accessible without login</div>
+                            </div>
+                            <label class="toggle-switch-label">
+                                <input type="checkbox" id="auth-toggle" class="channel-toggle" checked onchange="confirmAuthToggle(this)">
+                                <span class="toggle-switch-text">Enabled</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="card-header"><h2>Users</h2></div>
+                    <div class="card-body">
+                        <div class="table-wrap">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Username</th>
+                                        <th>Role</th>
+                                        <th>Status</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="user-list">
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="card-header"><h2>Create User</h2></div>
+                    <div class="card-body">
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Username</div>
+                            </div>
+                            <input type="text" id="new-user-username" class="setting-select" placeholder="username" autocomplete="off">
+                        </div>
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Password</div>
+                                <div class="setting-desc">Min 8 characters, at least one letter and one digit</div>
+                            </div>
+                            <input type="password" id="new-user-password" class="setting-select" placeholder="password" autocomplete="new-password">
+                        </div>
+                        <div class="setting-row">
+                            <div class="setting-info">
+                                <div class="setting-label">Role</div>
+                            </div>
+                            <select id="new-user-role" class="setting-select">
+                                <option value="viewer">viewer</option>
+                                <option value="operator">operator</option>
+                                <option value="admin">admin</option>
+                            </select>
+                        </div>
+                        <div class="setting-row" style="justify-content:flex-end">
+                            <button class="btn btn-success" onclick="createUser()">Create User</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {{end}}{{end}}{{end}}
     </main>
 
     <div id="toast-container" class="toast-container"></div>
     <script src="/static/app.js"></script>
+    <script src="/static/auth.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/static/setup.html
+++ b/internal/web/static/setup.html
@@ -1,0 +1,145 @@
+{{define "setup.html"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Setup — Docker-Sentinel</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <style>
+        .setup-wrap {
+            display: flex;
+            min-height: 100vh;
+            align-items: center;
+            justify-content: center;
+            padding: var(--sp-4);
+            background: var(--bg-body);
+        }
+        .setup-card {
+            width: 100%;
+            max-width: 460px;
+            background: var(--bg-surface);
+            border-radius: var(--radius-lg);
+            border: 1px solid var(--border);
+            padding: var(--sp-8);
+            box-shadow: var(--shadow-md);
+        }
+        .setup-logo {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: var(--sp-3);
+            margin-bottom: var(--sp-2);
+        }
+        .setup-logo .nav-logo {
+            width: 40px;
+            height: 40px;
+            font-size: 1.2rem;
+        }
+        .setup-logo-text {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--fg-primary);
+        }
+        .setup-subtitle {
+            text-align: center;
+            color: var(--fg-secondary);
+            margin-bottom: var(--sp-6);
+            font-size: 0.9rem;
+        }
+        .setup-form {
+            display: flex;
+            flex-direction: column;
+            gap: var(--sp-4);
+        }
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: var(--sp-1);
+        }
+        .form-label {
+            font-size: 0.875rem;
+            font-weight: 500;
+            color: var(--fg-secondary);
+        }
+        .form-hint {
+            font-size: 0.75rem;
+            color: var(--fg-secondary);
+            opacity: 0.7;
+        }
+        .form-input {
+            padding: 10px 14px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            background: var(--bg-input);
+            color: var(--fg-primary);
+            font-size: 0.95rem;
+            font-family: inherit;
+            outline: none;
+            transition: border-color 150ms var(--md-motion-standard);
+        }
+        .form-input:focus {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+        }
+        .setup-error {
+            padding: 10px 14px;
+            border-radius: var(--radius);
+            background: var(--error-bg);
+            color: var(--error-fg);
+            font-size: 0.875rem;
+            border: 1px solid var(--error);
+        }
+        .setup-btn {
+            padding: 12px;
+            font-size: 1rem;
+            font-weight: 500;
+            border: none;
+            border-radius: var(--radius);
+            background: var(--accent);
+            color: var(--md-on-primary);
+            cursor: pointer;
+            transition: opacity 150ms var(--md-motion-standard);
+        }
+        .setup-btn:hover { opacity: 0.9; }
+    </style>
+</head>
+<body>
+    <div class="setup-wrap">
+        <div class="setup-card">
+            <div class="setup-logo">
+                <span class="nav-logo">S</span>
+                <span class="setup-logo-text">Sentinel Setup</span>
+            </div>
+            <p class="setup-subtitle">Create your admin account to get started</p>
+
+            {{if .Error}}
+            <div class="setup-error" style="margin-bottom:var(--sp-4)">{{.Error}}</div>
+            {{end}}
+
+            <form class="setup-form" method="POST" action="/setup">
+                <input type="hidden" name="token" value="{{.Token}}">
+                <div class="form-group">
+                    <label class="form-label" for="username">Admin Username</label>
+                    <input class="form-input" type="text" id="username" name="username" autocomplete="username" autofocus required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="password">Password</label>
+                    <input class="form-input" type="password" id="password" name="password" autocomplete="new-password" required minlength="8">
+                    <span class="form-hint">Min 8 characters, must include a letter and a digit</span>
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="confirm">Confirm Password</label>
+                    <input class="form-input" type="password" id="confirm" name="confirm" autocomplete="new-password" required>
+                </div>
+                <button class="setup-btn" type="submit">Create Admin Account</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>
+{{end}}

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -2423,7 +2423,117 @@ table.managing .td-checkbox {
 
 
 /* --------------------------------------------------------------------------
-   28. Transitions — global defaults for interactive states
+   28. Nav User Dropdown
+   -------------------------------------------------------------------------- */
+
+.nav-user {
+    display: flex;
+    align-items: center;
+    position: relative;
+    flex-shrink: 0;
+}
+
+.nav-user-btn {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    padding: var(--sp-1) var(--sp-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--fg-secondary);
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 150ms, border-color 150ms;
+}
+
+.nav-user-btn:hover {
+    background: var(--bg-hover);
+    border-color: var(--border-strong);
+}
+
+.nav-user-role {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: var(--radius-full);
+    background: var(--md-primary-container);
+    color: var(--md-on-primary-container);
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    line-height: 1.4;
+}
+
+.nav-user-chevron {
+    font-size: 0.6rem;
+    transition: transform 150ms;
+}
+
+.nav-user-dropdown {
+    display: none;
+    position: absolute;
+    top: calc(100% + var(--sp-2));
+    right: 0;
+    min-width: 160px;
+    background: var(--md-surface-container-high);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-lg);
+    z-index: 200;
+    overflow: hidden;
+}
+
+.nav-user-dropdown.open {
+    display: block;
+}
+
+.nav-user-dropdown a,
+.nav-user-dropdown button {
+    display: block;
+    width: 100%;
+    padding: var(--sp-2) var(--sp-3);
+    border: none;
+    background: transparent;
+    color: var(--fg-primary);
+    font-size: 0.8rem;
+    font-weight: 500;
+    text-align: left;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 150ms;
+}
+
+.nav-user-dropdown a:hover,
+.nav-user-dropdown button:hover {
+    background: var(--bg-hover);
+}
+
+.nav-user-dropdown .dropdown-divider {
+    height: 1px;
+    margin: var(--sp-1) 0;
+    background: var(--border);
+}
+
+.nav-auth-off {
+    display: flex;
+    align-items: center;
+    padding: var(--sp-1) var(--sp-2);
+    font-size: 0.7rem;
+    color: var(--fg-muted);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+@media (max-width: 480px) {
+    .nav-user-btn span:not(.nav-user-chevron):not(.nav-user-role) {
+        display: none;
+    }
+}
+
+
+/* --------------------------------------------------------------------------
+   29. Transitions — global defaults for interactive states
    -------------------------------------------------------------------------- */
 
 /* Catch-all for elements that should have smooth transitions but are not


### PR DESCRIPTION
## Summary
- Multi-user authentication with bcrypt passwords, fine-grained permissions (10 capabilities), and 3 built-in roles (admin/operator/viewer)
- API bearer tokens (`stk_` prefix, SHA-256 hashed storage) for programmatic access
- First-run setup wizard with bootstrap token (printed to container logs), CSRF double-submit protection, login rate limiting with exponential backoff and account lockout
- Security tab in settings for user management and auth toggle (admin only)
- All self-contained in BoltDB — no external auth services required

## New files
- `internal/auth/` — 9 source files + 7 test files (55+ tests)
- `internal/store/bolt_auth.go` — user/session/role/token CRUD with atomic secondary indexes
- `internal/web/handlers_auth.go` — all auth HTTP handlers
- `internal/web/static/login.html`, `setup.html`, `account.html`, `auth.js` — frontend

## Test plan
- [x] All 55+ unit tests pass (passwords, sessions, CSRF, rate limiter, permissions, tokens, middleware)
- [x] Full test suite passes (`go test ./...`)
- [x] Gitea CI passes (build + lint)
- [x] Live smoke test: setup wizard, login/logout, API tokens, CSRF protection, unauthenticated access blocked, auth event logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)