### PR TITLE
fix: CI lint failures

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -39,9 +39,9 @@ type User struct {
 	RoleID         string    `json:"role_id"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
-	Locked         bool      `json:"locked"`        // locked after too many failed logins
-	LockedUntil    time.Time `json:"locked_until"`  // unlock time
-	FailedLogins   int       `json:"failed_logins"` // consecutive failures
+	Locked         bool      `json:"locked"`                     // locked after too many failed logins
+	LockedUntil    time.Time `json:"locked_until"`               // unlock time
+	FailedLogins   int       `json:"failed_logins"`              // consecutive failures
 	WebAuthnUserID []byte    `json:"webauthn_user_id,omitempty"` // stable opaque 64-byte random ID
 }
 
@@ -61,7 +61,7 @@ func (u *User) EnsureWebAuthnUserID() (bool, error) {
 
 // Session represents an active login session.
 type Session struct {
-	Token     string    `json:"token"`      // 64-char hex token (also the bucket key)
+	Token     string    `json:"token"` // 64-char hex token (also the bucket key)
 	UserID    string    `json:"user_id"`
 	IP        string    `json:"ip"`
 	UserAgent string    `json:"user_agent"`
@@ -79,13 +79,13 @@ type Role struct {
 
 // APIToken represents a bearer token for programmatic API access.
 type APIToken struct {
-	ID          string       `json:"id"`           // 16-char hex ID
-	Name        string       `json:"name"`         // user-friendly label
-	TokenHash   string       `json:"token_hash"`   // SHA-256 hex of the full token
+	ID          string       `json:"id"`         // 16-char hex ID
+	Name        string       `json:"name"`       // user-friendly label
+	TokenHash   string       `json:"token_hash"` // SHA-256 hex of the full token
 	UserID      string       `json:"user_id"`
-	Permissions []Permission `json:"permissions"`   // nil = inherit from user role
+	Permissions []Permission `json:"permissions"` // nil = inherit from user role
 	CreatedAt   time.Time    `json:"created_at"`
-	ExpiresAt   time.Time    `json:"expires_at"`    // zero = no expiry
+	ExpiresAt   time.Time    `json:"expires_at"` // zero = no expiry
 	LastUsedAt  time.Time    `json:"last_used_at"`
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -155,5 +155,5 @@ func ensureCSRFCookie(w http.ResponseWriter, r *http.Request, secure bool) {
 func writeJSONError(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	w.Write([]byte(`{"error":"` + msg + `"}`))
+	_, _ = w.Write([]byte(`{"error":"` + msg + `"}`))
 }

--- a/internal/auth/tokens_test.go
+++ b/internal/auth/tokens_test.go
@@ -70,7 +70,7 @@ func TestGenerateTokenID(t *testing.T) {
 
 func TestHashToken(t *testing.T) {
 	t.Run("is deterministic", func(t *testing.T) {
-		token := "stk_some-test-token"
+		token := "stk_some-test-token" //nolint:gosec // test value, not a real credential
 		h1 := HashToken(token)
 		h2 := HashToken(token)
 		if h1 != h2 {

--- a/internal/auth/webauthn.go
+++ b/internal/auth/webauthn.go
@@ -7,14 +7,14 @@ import (
 
 // WebAuthnCredential represents a stored WebAuthn passkey credential.
 type WebAuthnCredential struct {
-	ID              []byte                `json:"id"`               // credential ID (raw bytes)
-	PublicKey       []byte                `json:"public_key"`       // COSE-encoded public key
+	ID              []byte                `json:"id"`         // credential ID (raw bytes)
+	PublicKey       []byte                `json:"public_key"` // COSE-encoded public key
 	AttestationType string                `json:"attestation_type"`
 	Transport       []string              `json:"transport,omitempty"` // e.g. "usb", "ble", "internal"
 	Flags           WebAuthnFlags         `json:"flags"`
 	Authenticator   WebAuthnAuthenticator `json:"authenticator"`
-	UserID          string                `json:"user_id"`   // links to User.ID
-	Name            string                `json:"name"`      // user-friendly label (e.g. "MacBook Touch ID")
+	UserID          string                `json:"user_id"` // links to User.ID
+	Name            string                `json:"name"`    // user-friendly label (e.g. "MacBook Touch ID")
 	CreatedAt       time.Time             `json:"created_at"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,9 +35,9 @@ type Config struct {
 	WebEnabled bool
 
 	// Authentication
-	AuthEnabled    *bool         // nil = use DB default (true); non-nil = env override
-	SessionExpiry  time.Duration
-	CookieSecure   bool
+	AuthEnabled   *bool // nil = use DB default (true); non-nil = env override
+	SessionExpiry time.Duration
+	CookieSecure  bool
 
 	// TLS
 	TLSCert string // path to TLS certificate PEM file
@@ -69,27 +69,27 @@ func NewTestConfig() *Config {
 // Load reads all configuration from environment variables with defaults.
 func Load() *Config {
 	return &Config{
-		DockerSock:     envStr("SENTINEL_DOCKER_SOCK", "/var/run/docker.sock"),
-		pollInterval:   envDuration("SENTINEL_POLL_INTERVAL", 6*time.Hour),
-		gracePeriod:    envDuration("SENTINEL_GRACE_PERIOD", 30*time.Second),
-		defaultPolicy:  envStr("SENTINEL_DEFAULT_POLICY", "manual"),
-		DBPath:         envStr("SENTINEL_DB_PATH", "/data/sentinel.db"),
-		LogJSON:        envBool("SENTINEL_LOG_JSON", true),
-		GotifyURL:      envStr("SENTINEL_GOTIFY_URL", ""),
-		GotifyToken:    envStr("SENTINEL_GOTIFY_TOKEN", ""),
-		WebhookURL:     envStr("SENTINEL_WEBHOOK_URL", ""),
-		WebhookHeaders: envStr("SENTINEL_WEBHOOK_HEADERS", ""),
-		WebPort:        envStr("SENTINEL_WEB_PORT", "8080"),
-		WebEnabled:     envBool("SENTINEL_WEB_ENABLED", true),
-		AuthEnabled:    envBoolPtr("SENTINEL_AUTH_ENABLED"),
-		SessionExpiry:  envDuration("SENTINEL_SESSION_EXPIRY", 720*time.Hour),
-		CookieSecure:       envBool("SENTINEL_COOKIE_SECURE", true),
-		TLSCert:            envStr("SENTINEL_TLS_CERT", ""),
-		TLSKey:             envStr("SENTINEL_TLS_KEY", ""),
-		TLSAuto:            envBool("SENTINEL_TLS_AUTO", false),
-		WebAuthnRPID:       envStr("SENTINEL_WEBAUTHN_RPID", ""),
+		DockerSock:          envStr("SENTINEL_DOCKER_SOCK", "/var/run/docker.sock"),
+		pollInterval:        envDuration("SENTINEL_POLL_INTERVAL", 6*time.Hour),
+		gracePeriod:         envDuration("SENTINEL_GRACE_PERIOD", 30*time.Second),
+		defaultPolicy:       envStr("SENTINEL_DEFAULT_POLICY", "manual"),
+		DBPath:              envStr("SENTINEL_DB_PATH", "/data/sentinel.db"),
+		LogJSON:             envBool("SENTINEL_LOG_JSON", true),
+		GotifyURL:           envStr("SENTINEL_GOTIFY_URL", ""),
+		GotifyToken:         envStr("SENTINEL_GOTIFY_TOKEN", ""),
+		WebhookURL:          envStr("SENTINEL_WEBHOOK_URL", ""),
+		WebhookHeaders:      envStr("SENTINEL_WEBHOOK_HEADERS", ""),
+		WebPort:             envStr("SENTINEL_WEB_PORT", "8080"),
+		WebEnabled:          envBool("SENTINEL_WEB_ENABLED", true),
+		AuthEnabled:         envBoolPtr("SENTINEL_AUTH_ENABLED"),
+		SessionExpiry:       envDuration("SENTINEL_SESSION_EXPIRY", 720*time.Hour),
+		CookieSecure:        envBool("SENTINEL_COOKIE_SECURE", true),
+		TLSCert:             envStr("SENTINEL_TLS_CERT", ""),
+		TLSKey:              envStr("SENTINEL_TLS_KEY", ""),
+		TLSAuto:             envBool("SENTINEL_TLS_AUTO", false),
+		WebAuthnRPID:        envStr("SENTINEL_WEBAUTHN_RPID", ""),
 		WebAuthnDisplayName: envStr("SENTINEL_WEBAUTHN_DISPLAY_NAME", "Docker-Sentinel"),
-		WebAuthnOrigins:    envStr("SENTINEL_WEBAUTHN_ORIGINS", ""),
+		WebAuthnOrigins:     envStr("SENTINEL_WEBAUTHN_ORIGINS", ""),
 	}
 }
 
@@ -136,24 +136,24 @@ func (c *Config) Values() map[string]string {
 	c.mu.RUnlock()
 
 	return map[string]string{
-		"SENTINEL_DOCKER_SOCK":    c.DockerSock,
-		"SENTINEL_POLL_INTERVAL":  pi.String(),
-		"SENTINEL_GRACE_PERIOD":   gp.String(),
-		"SENTINEL_DEFAULT_POLICY": dp,
-		"SENTINEL_DB_PATH":        c.DBPath,
-		"SENTINEL_LOG_JSON":       fmt.Sprintf("%t", c.LogJSON),
-		"SENTINEL_GOTIFY_URL":     c.GotifyURL,
-		"SENTINEL_WEBHOOK_URL":    c.WebhookURL,
-		"SENTINEL_WEB_PORT":       c.WebPort,
-		"SENTINEL_WEB_ENABLED":    fmt.Sprintf("%t", c.WebEnabled),
-		"SENTINEL_SESSION_EXPIRY":          c.SessionExpiry.String(),
-		"SENTINEL_COOKIE_SECURE":           fmt.Sprintf("%t", c.CookieSecure),
-		"SENTINEL_TLS_CERT":                c.TLSCert,
-		"SENTINEL_TLS_KEY":                 redactPath(c.TLSKey),
-		"SENTINEL_TLS_AUTO":                fmt.Sprintf("%t", c.TLSAuto),
-		"SENTINEL_WEBAUTHN_RPID":           c.WebAuthnRPID,
-		"SENTINEL_WEBAUTHN_DISPLAY_NAME":   c.WebAuthnDisplayName,
-		"SENTINEL_WEBAUTHN_ORIGINS":        c.WebAuthnOrigins,
+		"SENTINEL_DOCKER_SOCK":           c.DockerSock,
+		"SENTINEL_POLL_INTERVAL":         pi.String(),
+		"SENTINEL_GRACE_PERIOD":          gp.String(),
+		"SENTINEL_DEFAULT_POLICY":        dp,
+		"SENTINEL_DB_PATH":               c.DBPath,
+		"SENTINEL_LOG_JSON":              fmt.Sprintf("%t", c.LogJSON),
+		"SENTINEL_GOTIFY_URL":            c.GotifyURL,
+		"SENTINEL_WEBHOOK_URL":           c.WebhookURL,
+		"SENTINEL_WEB_PORT":              c.WebPort,
+		"SENTINEL_WEB_ENABLED":           fmt.Sprintf("%t", c.WebEnabled),
+		"SENTINEL_SESSION_EXPIRY":        c.SessionExpiry.String(),
+		"SENTINEL_COOKIE_SECURE":         fmt.Sprintf("%t", c.CookieSecure),
+		"SENTINEL_TLS_CERT":              c.TLSCert,
+		"SENTINEL_TLS_KEY":               redactPath(c.TLSKey),
+		"SENTINEL_TLS_AUTO":              fmt.Sprintf("%t", c.TLSAuto),
+		"SENTINEL_WEBAUTHN_RPID":         c.WebAuthnRPID,
+		"SENTINEL_WEBAUTHN_DISPLAY_NAME": c.WebAuthnDisplayName,
+		"SENTINEL_WEBAUTHN_ORIGINS":      c.WebAuthnOrigins,
 	}
 }
 

--- a/internal/store/bolt.go
+++ b/internal/store/bolt.go
@@ -13,12 +13,12 @@ import (
 )
 
 var (
-	bucketSnapshots = []byte("snapshots")
-	bucketHistory   = []byte("history")
-	bucketState     = []byte("state")
-	bucketQueue     = []byte("queue")
-	bucketPolicies  = []byte("policies")
-	bucketLogs      = []byte("logs")
+	bucketSnapshots   = []byte("snapshots")
+	bucketHistory     = []byte("history")
+	bucketState       = []byte("state")
+	bucketQueue       = []byte("queue")
+	bucketPolicies    = []byte("policies")
+	bucketLogs        = []byte("logs")
 	bucketSettings    = []byte("settings")
 	bucketNotifyState = []byte("notify_state")
 	bucketNotifyPrefs = []byte("notify_prefs")

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -272,10 +272,10 @@ func (s *Server) apiCheck(w http.ResponseWriter, r *http.Request) {
 		})
 		s.deps.Log.Info("update found via manual check", "name", name)
 		writeJSON(w, http.StatusOK, map[string]any{
-			"status":          "update_available",
-			"name":            name,
-			"message":         "Update available for " + name,
-			"newer_versions":  newerVersions,
+			"status":         "update_available",
+			"name":           name,
+			"message":        "Update available for " + name,
+			"newer_versions": newerVersions,
 		})
 		return
 	}

--- a/internal/web/handlers_webauthn.go
+++ b/internal/web/handlers_webauthn.go
@@ -21,10 +21,10 @@ type webauthnUser struct {
 	creds []webauthn.Credential
 }
 
-func (wu *webauthnUser) WebAuthnID() []byte                          { return wu.user.WebAuthnUserID }
-func (wu *webauthnUser) WebAuthnName() string                        { return wu.user.Username }
-func (wu *webauthnUser) WebAuthnDisplayName() string                 { return wu.user.Username }
-func (wu *webauthnUser) WebAuthnCredentials() []webauthn.Credential  { return wu.creds }
+func (wu *webauthnUser) WebAuthnID() []byte                         { return wu.user.WebAuthnUserID }
+func (wu *webauthnUser) WebAuthnName() string                       { return wu.user.Username }
+func (wu *webauthnUser) WebAuthnDisplayName() string                { return wu.user.Username }
+func (wu *webauthnUser) WebAuthnCredentials() []webauthn.Credential { return wu.creds }
 
 // toWebAuthnCredentials converts auth.WebAuthnCredential slice to webauthn.Credential slice.
 func toWebAuthnCredentials(creds []auth.WebAuthnCredential) []webauthn.Credential {
@@ -444,4 +444,3 @@ func (s *Server) apiPasskeysAvailable(w http.ResponseWriter, r *http.Request) {
 		"available":  available,
 	})
 }
-


### PR DESCRIPTION
## Summary
- Fix gofmt formatting across 6 files
- Fix unchecked `w.Write` error in auth middleware
- Suppress gosec G101 false positive in test file

## Test plan
- [x] `make lint` passes locally
- [x] `go test ./...` passes locally