### PR TITLE
fix: repair shared network namespaces after container updates

### DIFF
--- a/internal/docker/interface.go
+++ b/internal/docker/interface.go
@@ -17,6 +17,7 @@ type API interface {
 	RemoveContainer(ctx context.Context, id string) error
 	CreateContainer(ctx context.Context, name string, cfg *container.Config, hostCfg *container.HostConfig, netCfg *network.NetworkingConfig) (string, error)
 	StartContainer(ctx context.Context, id string) error
+	RestartContainer(ctx context.Context, id string) error
 	PullImage(ctx context.Context, refStr string) error
 	ImageDigest(ctx context.Context, imageRef string) (string, error)
 	DistributionDigest(ctx context.Context, imageRef string) (string, error)

--- a/internal/engine/mock_test.go
+++ b/internal/engine/mock_test.go
@@ -32,6 +32,9 @@ type mockDocker struct {
 	startCalls []string
 	startErr   map[string]error
 
+	restartCalls []string
+	restartErr   map[string]error
+
 	pullCalls []string
 	pullErr   map[string]error
 
@@ -51,6 +54,7 @@ func newMockDocker() *mockDocker {
 		createResult:   make(map[string]string),
 		createErr:      make(map[string]error),
 		startErr:       make(map[string]error),
+		restartErr:     make(map[string]error),
 		pullErr:        make(map[string]error),
 		imageDigests:   make(map[string]string),
 		imageDigestErr: make(map[string]error),
@@ -112,6 +116,16 @@ func (m *mockDocker) StartContainer(_ context.Context, id string) error {
 	m.startCalls = append(m.startCalls, id)
 	m.mu.Unlock()
 	if err, ok := m.startErr[id]; ok {
+		return err
+	}
+	return nil
+}
+
+func (m *mockDocker) RestartContainer(_ context.Context, id string) error {
+	m.mu.Lock()
+	m.restartCalls = append(m.restartCalls, id)
+	m.mu.Unlock()
+	if err, ok := m.restartErr[id]; ok {
 		return err
 	}
 	return nil

--- a/internal/registry/checker_test.go
+++ b/internal/registry/checker_test.go
@@ -42,8 +42,9 @@ func (m *mockDockerForRegistry) RemoveContainer(_ context.Context, _ string) err
 func (m *mockDockerForRegistry) CreateContainer(_ context.Context, _ string, _ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig) (string, error) {
 	return "", nil
 }
-func (m *mockDockerForRegistry) StartContainer(_ context.Context, _ string) error { return nil }
-func (m *mockDockerForRegistry) PullImage(_ context.Context, _ string) error      { return nil }
+func (m *mockDockerForRegistry) StartContainer(_ context.Context, _ string) error  { return nil }
+func (m *mockDockerForRegistry) RestartContainer(_ context.Context, _ string) error { return nil }
+func (m *mockDockerForRegistry) PullImage(_ context.Context, _ string) error       { return nil }
 func (m *mockDockerForRegistry) Close() error                                     { return nil }
 
 func (m *mockDockerForRegistry) ImageDigest(_ context.Context, ref string) (string, error) {


### PR DESCRIPTION
## Summary
- Add `repairNetworkNamespace()` post-update step to handle `network_mode: container:X` containers
- **Consumer fix:** After updating a container that uses another's namespace, verify its `SandboxKey` — restart if empty (broken namespace)
- **Provider fix:** After updating a provider container, find and restart all dependents sharing its namespace
- Add `RestartContainer` to the `docker.API` interface (method already existed on concrete client)
- 4 test cases covering consumer repair, healthy skip, provider dependent restart, and no-dependents

## Test plan
- [x] All tests pass locally (`go test ./...`)
- [x] Deployed as v1.12.3 and verified on live server
- [x] Dashboard loads, SSE live, initial scan completes
- [x] CI green on Gitea

🤖 Generated with [Claude Code](https://claude.com/claude-code)