### PR TITLE
fix: gofmt trailing newline in updater.go

### DIFF
--- a/internal/engine/updater.go
+++ b/internal/engine/updater.go
@@ -590,4 +590,3 @@ func (u *Updater) checkGHCRAlternatives(ctx context.Context, containers []contai
 		u.publishEvent(events.EventGHCRCheck, "", fmt.Sprintf("checked %d images", checked))
 	}
 }
-


### PR DESCRIPTION
Fixes lint failure from v2.0.1 release CI.