### PR TITLE
feat: implement update-to-version for containers and self-update

### DIFF
--- a/cmd/sentinel/adapters.go
+++ b/cmd/sentinel/adapters.go
@@ -399,8 +399,8 @@ type selfUpdateAdapter struct {
 	updater *engine.SelfUpdater
 }
 
-func (a *selfUpdateAdapter) Update(ctx context.Context) error {
-	return a.updater.Update(ctx)
+func (a *selfUpdateAdapter) Update(ctx context.Context, targetImage string) error {
+	return a.updater.Update(ctx, targetImage)
 }
 
 // stopAdapter bridges docker.Client to web.ContainerStopper.

--- a/internal/engine/selfupdate.go
+++ b/internal/engine/selfupdate.go
@@ -26,7 +26,7 @@ func NewSelfUpdater(d docker.API, log *logging.Logger) *SelfUpdater {
 // Update performs a self-update by creating an ephemeral helper container.
 // The helper pulls the new image, stops/removes the current Sentinel container,
 // and recreates it with the same configuration.
-func (su *SelfUpdater) Update(ctx context.Context) error {
+func (su *SelfUpdater) Update(ctx context.Context, targetImage string) error {
 	// 1. Find our own container.
 	containers, err := su.docker.ListContainers(ctx)
 	if err != nil {
@@ -61,6 +61,9 @@ func (su *SelfUpdater) Update(ctx context.Context) error {
 	}
 
 	imageRef := inspect.Config.Image
+	if targetImage != "" {
+		imageRef = targetImage
+	}
 	su.log.Info("self-update initiated", "name", selfName, "image", imageRef)
 
 	// 3. Build the docker run arguments from the inspect config.

--- a/internal/engine/selfupdate_test.go
+++ b/internal/engine/selfupdate_test.go
@@ -1,0 +1,138 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Will-Luck/Docker-Sentinel/internal/logging"
+	"github.com/moby/moby/api/types/container"
+)
+
+func newTestSelfUpdater(mock *mockDocker) *SelfUpdater {
+	return NewSelfUpdater(mock, logging.New(false))
+}
+
+func sentinelContainer(id, name, image string) container.Summary {
+	return container.Summary{
+		ID:     id,
+		Names:  []string{"/" + name},
+		Image:  image,
+		Labels: map[string]string{"sentinel.self": "true"},
+	}
+}
+
+func sentinelInspect(image string) container.InspectResponse {
+	return container.InspectResponse{
+		Config: &container.Config{
+			Image:  image,
+			Env:    []string{"SENTINEL_WEB_PORT=8080"},
+			Labels: map[string]string{"sentinel.self": "true"},
+		},
+		HostConfig: &container.HostConfig{
+			RestartPolicy: container.RestartPolicy{Name: "unless-stopped"},
+		},
+	}
+}
+
+func TestSelfUpdateUsesOriginalImage(t *testing.T) {
+	mock := newMockDocker()
+	mock.containers = []container.Summary{sentinelContainer("abc123", "sentinel", "ghcr.io/will-luck/docker-sentinel:2.2.0")}
+	mock.inspectResults["abc123"] = sentinelInspect("ghcr.io/will-luck/docker-sentinel:2.2.0")
+
+	su := newTestSelfUpdater(mock)
+	if err := su.Update(context.Background(), ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mock.createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(mock.createCalls))
+	}
+
+	// Helper name should start with sentinel-updater-
+	if !strings.HasPrefix(mock.createCalls[0], "sentinel-updater-") {
+		t.Errorf("expected helper name prefix 'sentinel-updater-', got %q", mock.createCalls[0])
+	}
+
+	// Script in Cmd should reference the original image, not a different one.
+	cfg := mock.createConfigs[mock.createCalls[0]]
+	if cfg == nil {
+		t.Fatal("no config captured for helper container")
+	}
+	script := strings.Join(cfg.Cmd, " ")
+	if !strings.Contains(script, "ghcr.io/will-luck/docker-sentinel:2.2.0") {
+		t.Errorf("script should contain original image ref, got: %s", script)
+	}
+}
+
+func TestSelfUpdateUsesTargetImage(t *testing.T) {
+	mock := newMockDocker()
+	mock.containers = []container.Summary{sentinelContainer("abc123", "sentinel", "ghcr.io/will-luck/docker-sentinel:2.2.0")}
+	mock.inspectResults["abc123"] = sentinelInspect("ghcr.io/will-luck/docker-sentinel:2.2.0")
+
+	su := newTestSelfUpdater(mock)
+	if err := su.Update(context.Background(), "ghcr.io/will-luck/docker-sentinel:2.3.1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg := mock.createConfigs[mock.createCalls[0]]
+	if cfg == nil {
+		t.Fatal("no config captured for helper container")
+	}
+	script := strings.Join(cfg.Cmd, " ")
+
+	// Script should reference the target image, not the original.
+	if !strings.Contains(script, "ghcr.io/will-luck/docker-sentinel:2.3.1") {
+		t.Errorf("script should contain target image ref, got: %s", script)
+	}
+	if strings.Contains(script, "docker-sentinel:2.2.0") {
+		t.Errorf("script should NOT contain original image ref, got: %s", script)
+	}
+}
+
+func TestSelfUpdateNoSentinelContainer(t *testing.T) {
+	mock := newMockDocker()
+	mock.containers = []container.Summary{
+		{ID: "xyz", Names: []string{"/some-other"}, Labels: map[string]string{}},
+	}
+
+	su := newTestSelfUpdater(mock)
+	err := su.Update(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error when no sentinel container found")
+	}
+	if !strings.Contains(err.Error(), "could not find sentinel container") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestSelfUpdateInspectFails(t *testing.T) {
+	mock := newMockDocker()
+	mock.containers = []container.Summary{sentinelContainer("abc123", "sentinel", "img:1.0")}
+	mock.inspectErr["abc123"] = ErrUpdateInProgress
+
+	su := newTestSelfUpdater(mock)
+	err := su.Update(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error when inspect fails")
+	}
+	if !strings.Contains(err.Error(), "inspect self") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestSelfUpdateHelperLifecycle(t *testing.T) {
+	mock := newMockDocker()
+	mock.containers = []container.Summary{sentinelContainer("abc123", "sentinel", "img:1.0")}
+	mock.inspectResults["abc123"] = sentinelInspect("img:1.0")
+
+	su := newTestSelfUpdater(mock)
+	err := su.Update(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mock.startCalls) != 1 {
+		t.Fatalf("expected 1 start call, got %d", len(mock.startCalls))
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -110,7 +110,7 @@ type EventLogger interface {
 
 // SelfUpdater triggers self-update via an ephemeral helper container.
 type SelfUpdater interface {
-	Update(ctx context.Context) error
+	Update(ctx context.Context, targetImage string) error
 }
 
 // NotificationConfigStore persists notification channel configuration.
@@ -688,6 +688,7 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("POST /api/check/{name}", perm(auth.PermContainersUpdate, s.apiCheck))
 	s.mux.Handle("POST /api/scan", perm(auth.PermContainersUpdate, s.apiTriggerScan))
 	s.mux.Handle("POST /api/containers/{name}/switch-ghcr", perm(auth.PermContainersUpdate, s.apiSwitchToGHCR))
+	s.mux.Handle("POST /api/containers/{name}/update-to-version", perm(auth.PermContainersUpdate, s.apiUpdateToVersion))
 
 	// containers.approve — {key} is the queue key: plain name for local, "hostID::name" for remote.
 	s.mux.Handle("POST /api/approve/{key}", perm(auth.PermContainersApprove, s.apiApprove))

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -1353,9 +1353,24 @@ function switchToGHCR(name, ghcrImage) {
 
 function updateToVersion(name) {
     var sel = document.getElementById("version-select");
-    if (!sel) return;
-    var version = sel.value;
-    showToast("Version pinning to " + version + " is not yet implemented", "info");
+    if (!sel || !sel.value) return;
+    var tag = sel.value;
+    showConfirm("Update to Version",
+        "<p>Update <strong>" + name + "</strong> to <code>" + tag + "</code>?</p>"
+    ).then(function(confirmed) {
+        if (!confirmed) return;
+        fetch("/api/containers/" + encodeURIComponent(name) + "/update-to-version", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({tag: tag})
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.error) { showToast(data.error, "error"); }
+            else { showToast(data.message || "Update started", "success"); }
+        })
+        .catch(function() { showToast("Failed to trigger version update", "error"); });
+    });
 }
 
 function applyBulkPolicy() {


### PR DESCRIPTION
## Summary
- Add `POST /api/containers/{name}/update-to-version` endpoint that accepts a `{"tag":"x.y.z"}` body
- Regular containers route through `UpdateContainer` lifecycle (snapshot → pull → stop → rm → create → start → validate → rollback)
- Sentinel (protected) containers route through the self-updater helper container pattern, now accepting a `targetImage` override instead of always re-pulling the pinned tag
- Frontend stub replaced with real API call + confirmation dialog

## Changes
| File | Change |
|------|--------|
| `internal/engine/selfupdate.go` | `Update()` accepts `targetImage` param — overrides `inspect.Config.Image` when non-empty |
| `internal/web/server.go` | Updated `SelfUpdater` interface + new route registration |
| `internal/web/api_control.go` | New `apiUpdateToVersion` handler, updated `apiSelfUpdate` to pass empty string |
| `cmd/sentinel/adapters.go` | Updated adapter to pass `targetImage` through |
| `internal/web/static/app.js` | Replaced "not yet implemented" toast with real API call + confirm dialog |
| `internal/engine/mock_test.go` | Added `createConfigs` capture for test assertions |
| `internal/engine/selfupdate_test.go` | 5 new tests covering targetImage override, error paths |

## Test plan
- [x] `go test ./...` — all packages pass
- [ ] Deploy dev build, open container detail page, select a version from the dropdown and click "Update to Version"
- [ ] Verify regular container updates to the selected tag
- [ ] Verify Sentinel self-update to a selected tag via helper container