### PR TITLE
fix: registry test button no longer wipes unsaved credentials

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -4343,8 +4343,16 @@ function testRegistryCredential(index) {
     .then(function(data) {
         if (data.success) {
             showToast("Credentials valid for " + cred.registry, "success");
-            // Probe runs server-side in background; re-fetch after it completes.
-            setTimeout(function() { loadRegistries(); }, 3000);
+            // Refresh rate-limit status after background probe, but don't
+            // reload credentials — unsaved entries would be wiped.
+            setTimeout(function() {
+                fetch("/api/settings/registries")
+                    .then(function(r) { return r.json(); })
+                    .then(function(d) {
+                        registryData = d;
+                        renderRegistryStatus();
+                    });
+            }, 3000);
         } else {
             showToast("Test failed: " + (data.error || "unknown error"), "error");
         }


### PR DESCRIPTION
## Summary
- After a successful credential test, the delayed `loadRegistries()` call was resetting the in-memory credential array from backend data, which doesn't include unsaved entries
- Now only refreshes rate-limit status table without touching the credential form state

## Test plan
- [ ] Settings → Registries → add credential → fill username/token → click Test → wait 3s → credential still visible
- [ ] Save All still works after testing
- [ ] Rate limit status table still updates after test

Fixes #29