### PR TITLE
fix: safer update defaults, version resolution for all non-semver tags

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,7 +94,7 @@ func Load() *Config {
 		pollInterval:        envDuration("SENTINEL_POLL_INTERVAL", 6*time.Hour),
 		gracePeriod:         envDuration("SENTINEL_GRACE_PERIOD", 30*time.Second),
 		defaultPolicy:       envStr("SENTINEL_DEFAULT_POLICY", "manual"),
-		latestAutoUpdate:    envBool("SENTINEL_LATEST_AUTO_UPDATE", true),
+		latestAutoUpdate:    envBool("SENTINEL_LATEST_AUTO_UPDATE", false),
 		DBPath:              envStr("SENTINEL_DB_PATH", "/data/sentinel.db"),
 		LogJSON:             envBool("SENTINEL_LOG_JSON", true),
 		GotifyURL:           envStr("SENTINEL_GOTIFY_URL", ""),

--- a/internal/registry/checker.go
+++ b/internal/registry/checker.go
@@ -134,7 +134,7 @@ func (c *Checker) CheckVersionedWithDigest(ctx context.Context, imageRef, knownD
 
 	_, ok := ParseSemVer(tag)
 	if !ok {
-		if result.UpdateAvailable && (tag == "latest" || tag == "") {
+		if result.UpdateAvailable {
 			c.resolveLatestVersions(ctx, imageRef, &result)
 		}
 		return result
@@ -201,7 +201,7 @@ func (c *Checker) CheckVersioned(ctx context.Context, imageRef string) CheckResu
 	if !ok {
 		// Non-semver tag (e.g. "latest") — resolve digest-to-version if
 		// an update was detected so the UI can show meaningful versions.
-		if result.UpdateAvailable && (tag == "latest" || tag == "") {
+		if result.UpdateAvailable {
 			c.resolveLatestVersions(ctx, imageRef, &result)
 		}
 		return result


### PR DESCRIPTION
## Summary
- Change `SENTINEL_LATEST_AUTO_UPDATE` default from `true` to `false` — `:latest` containers now respect the global `manual` policy like everything else. Nothing auto-updates unless explicitly opted in via env var, Docker label, or dashboard policy.
- Broaden `resolveLatestVersions()` to run for **any** non-semver tag with a digest change (not just `:latest`). Tags like `:release`, `:3`, `:stable` now get digest-to-version resolution so the UI shows e.g. `3.3.0 → 3.4.7` instead of `3 → 3`.

## Test plan
- [x] `go test ./...` passes
- [ ] Container with `:latest` tag and no explicit policy override stays on `manual` (queued, not auto-updated)
- [ ] Container with `:release` tag shows resolved version info when update detected
- [ ] Setting `SENTINEL_LATEST_AUTO_UPDATE=true` restores old behavior

Ref #35