### PR TITLE
feat: surface skipped containers in history and scan toast

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -2739,7 +2739,7 @@ function initSSE() {
         }
     });
 
-    es.addEventListener("scan_complete", function () {
+    es.addEventListener("scan_complete", function (e) {
         // Clear scan button spinner.
         var scanBtn = document.getElementById("scan-btn");
         if (scanBtn) { scanBtn.classList.remove("loading"); scanBtn.disabled = false; }
@@ -2754,6 +2754,16 @@ function initSSE() {
             scheduleDigestBannerRefresh();
         } else {
             scheduleReload();
+        }
+        // Show warning toast if containers were skipped or failed.
+        var msg = e.data || "";
+        var rl = (msg.match(/rate_limited=(\d+)/) || [])[1] | 0;
+        var failed = (msg.match(/failed=(\d+)/) || [])[1] | 0;
+        if (rl > 0 || failed > 0) {
+            var parts = [];
+            if (rl > 0) parts.push(rl + " skipped (rate limit)");
+            if (failed > 0) parts.push(failed + " failed");
+            showToast("Scan complete \u2014 " + parts.join(", "), "warning");
         }
     });
 

--- a/internal/web/static/container.html
+++ b/internal/web/static/container.html
@@ -217,6 +217,7 @@
                                     <td>
                                         {{if eq .Outcome "success"}}<span class="badge badge-success">Success</span>
                                         {{else if eq .Outcome "rollback"}}<span class="badge badge-error">Rollback</span>
+                                        {{else if eq .Outcome "skipped"}}<span class="badge badge-warning">Skipped</span>
                                         {{else}}<span class="badge badge-muted">{{.Outcome}}</span>{{end}}
                                     </td>
                                     <td class="mono">{{fmtDuration .Duration}}</td>

--- a/internal/web/static/history.html
+++ b/internal/web/static/history.html
@@ -97,6 +97,8 @@
                                         <span class="badge badge-error">Failed</span>
                                     {{else if eq $r.Outcome "finalise_warning"}}
                                         <span class="badge badge-warning">Warning</span>
+                                    {{else if eq $r.Outcome "skipped"}}
+                                        <span class="badge badge-warning">Skipped</span>
                                     {{else}}
                                         <span class="badge badge-muted">{{$r.Outcome}}</span>
                                     {{end}}


### PR DESCRIPTION
## Summary
- Record rate-limited and registry-error skipped containers as "Skipped" entries in the update history with the reason
- Enrich `scan_complete` SSE event with all `ScanResult` counts (queued, skipped, rate_limited, failed)
- Show warning toast after scan when containers were skipped or failed
- Add "Skipped" badge (yellow) to history and container detail templates

## Test plan
- [x] `go test ./...` passes
- [ ] Trigger scan with rate-limited registry: history shows "Skipped" entries, warning toast appears
- [ ] Clean scan (no issues): no toast, no noise

Ref #35