### PR TITLE
feat: display port mappings on dashboard (WIP)

### DIFF
--- a/cmd/sentinel/adapters.go
+++ b/cmd/sentinel/adapters.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Will-Luck/Docker-Sentinel/internal/cluster"
 	clusterserver "github.com/Will-Luck/Docker-Sentinel/internal/cluster/server"
+	"github.com/moby/moby/api/types/container"
 	"github.com/Will-Luck/Docker-Sentinel/internal/docker"
 	"github.com/Will-Luck/Docker-Sentinel/internal/engine"
 	"github.com/Will-Luck/Docker-Sentinel/internal/events"
@@ -247,6 +248,7 @@ func (a *dockerAdapter) ListContainers(ctx context.Context) ([]web.ContainerSumm
 			Image:  c.Image,
 			Labels: c.Labels,
 			State:  string(c.State),
+			Ports:  convertPorts(c.Ports),
 		}
 	}
 	return result, nil
@@ -265,9 +267,31 @@ func (a *dockerAdapter) ListAllContainers(ctx context.Context) ([]web.ContainerS
 			Image:  c.Image,
 			Labels: c.Labels,
 			State:  string(c.State),
+			Ports:  convertPorts(c.Ports),
 		}
 	}
 	return result, nil
+}
+
+// convertPorts maps Docker container.PortSummary slices to web.PortMapping.
+func convertPorts(ports []container.PortSummary) []web.PortMapping {
+	if len(ports) == 0 {
+		return nil
+	}
+	result := make([]web.PortMapping, len(ports))
+	for i, p := range ports {
+		hostIP := ""
+		if p.IP.IsValid() {
+			hostIP = p.IP.String()
+		}
+		result[i] = web.PortMapping{
+			HostIP:        hostIP,
+			HostPort:      p.PublicPort,
+			ContainerPort: p.PrivatePort,
+			Protocol:      p.Type,
+		}
+	}
+	return result
 }
 
 func (a *dockerAdapter) InspectContainer(ctx context.Context, id string) (web.ContainerInspect, error) {

--- a/internal/web/handlers_dashboard.go
+++ b/internal/web/handlers_dashboard.go
@@ -102,6 +102,8 @@ type containerView struct {
 	Replicas        string // e.g. "3/3" for services, empty for containers
 	HostID          string // cluster host ID (empty = local)
 	HostName        string // cluster host name (empty = local)
+	Ports           []PortMapping
+	WebURL          string // first usable http(s) URL derived from port mappings
 }
 
 // stackGroup groups containers by their Docker Compose project name.
@@ -230,6 +232,26 @@ func (s *Server) buildServiceView(d ServiceDetail, pendingNames map[string]bool)
 	return sv
 }
 
+// containerWebURL returns the first usable HTTP URL derived from port mappings.
+// It picks the first host-mapped TCP port and builds a URL from it.
+func containerWebURL(ports []PortMapping) string {
+	for _, p := range ports {
+		if p.HostPort == 0 || p.Protocol == "udp" {
+			continue
+		}
+		scheme := "http"
+		if p.ContainerPort == 443 || p.ContainerPort == 8443 {
+			scheme = "https"
+		}
+		host := p.HostIP
+		if host == "" || host == "0.0.0.0" || host == "::" {
+			host = "localhost"
+		}
+		return fmt.Sprintf("%s://%s:%d", scheme, host, p.HostPort)
+	}
+	return ""
+}
+
 // handleDashboard renders the main container dashboard.
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	s.signalScanReady()
@@ -322,6 +344,8 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			IsSelf:          c.Labels["sentinel.self"] == "true",
 			Stack:           c.Labels["com.docker.compose.project"],
 			Registry:        registry.RegistryHost(c.Image),
+			Ports:           c.Ports,
+			WebURL:          containerWebURL(c.Ports),
 		})
 	}
 

--- a/internal/web/interfaces.go
+++ b/internal/web/interfaces.go
@@ -427,6 +427,14 @@ type ContainerLister interface {
 	InspectContainer(ctx context.Context, id string) (ContainerInspect, error)
 }
 
+// PortMapping describes a single host ↔ container port binding.
+type PortMapping struct {
+	HostIP        string `json:"host_ip,omitempty"`
+	HostPort      uint16 `json:"host_port,omitempty"`
+	ContainerPort uint16 `json:"container_port"`
+	Protocol      string `json:"protocol"` // "tcp" or "udp"
+}
+
 // ContainerSummary is a minimal container info struct.
 type ContainerSummary struct {
 	ID     string
@@ -434,6 +442,7 @@ type ContainerSummary struct {
 	Image  string
 	Labels map[string]string
 	State  string
+	Ports  []PortMapping
 }
 
 // ContainerInspect has just what the dashboard needs.

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -132,10 +132,11 @@
                 <table id="container-table">
                     <colgroup>
                         <col style="width:40px">
-                        <col style="width:22%">
+                        <col style="width:20%">
                         <col>
                         <col style="width:120px">
                         <col style="width:100px">
+                        <col style="width:110px">
                         <col style="width:220px">
                     </colgroup>
                     <thead>
@@ -155,6 +156,7 @@
                                 </span>
                             </th>
                             <th>Status</th>
+                            <th>Ports</th>
                             <th>Actions</th>
                         </tr>
                     </thead>
@@ -162,7 +164,7 @@
                         {{range .HostGroups}}
                         <tbody class="host-group" data-host="{{.ID}}" data-tab="{{.ID}}">
                             <tr class="host-header{{if not .Connected}} host-offline{{end}}" onclick="toggleHostGroup(this)">
-                                <td colspan="6">
+                                <td colspan="7">
                                     <div class="host-header-inner">
                                         <span class="expand-icon">&#9656;</span>
                                         <span class="host-status-dot {{if .Connected}}connected{{else}}disconnected{{end}}"></span>
@@ -174,7 +176,7 @@
                             </tr>
                             {{range .Stacks}}
                             <tr class="stack-header{{if .HasPending}} stack-pending{{end}}" data-stack="{{.Name}}" onclick="toggleStack(this)">
-                                <td colspan="6">
+                                <td colspan="7">
                                     <div class="stack-header-inner">
                                         <span class="stack-drag-handle" title="Drag to reorder">&#10495;</span>
                                         <input type="checkbox" class="stack-select" data-stack="{{.Name}}" title="Select all in {{.Name}}" onclick="event.stopPropagation()">
@@ -198,7 +200,7 @@
                         {{range .Stacks}}
                         <tbody class="stack-group stack-collapsed{{if gt .StoppedCount 0}} stack-has-stopped{{else if .HasPending}} stack-has-pending{{else}} stack-healthy{{end}}" data-stack="{{.Name}}" data-tab="local">
                             <tr class="stack-header{{if .HasPending}} stack-pending{{end}}" onclick="toggleStack(this)">
-                                <td colspan="6">
+                                <td colspan="7">
                                     <div class="stack-header-inner">
                                         <span class="stack-drag-handle" title="Drag to reorder">&#10495;</span>
                                         <input type="checkbox" class="stack-select" data-stack="{{.Name}}" title="Select all in {{.Name}}" onclick="event.stopPropagation()">
@@ -220,7 +222,7 @@
                     {{else}}
                         <tbody>
                             <tr>
-                                <td colspan="6">
+                                <td colspan="7">
                                     <div class="empty-state">
                                         <h3>No containers found</h3>
                                         <p>Sentinel is not monitoring any containers yet.</p>
@@ -232,7 +234,7 @@
 
                     {{if .SwarmServices}}
                     <tbody class="section-separator swarm-section" data-tab="swarm">
-                        <tr onclick="toggleSwarmSection(this)" style="cursor:pointer"><td colspan="6"><div class="section-divider">
+                        <tr onclick="toggleSwarmSection(this)" style="cursor:pointer"><td colspan="7"><div class="section-divider">
                             <span class="expand-icon">&#9662;</span>
                             <span class="section-title">Swarm Services</span>
                             <span class="section-summary">{{len .SwarmServices}} services</span>
@@ -289,6 +291,7 @@
                                 </span>
                                 {{end}}
                             </td>
+                            <td class="cell-ports"></td>
                             <td>
                                 <div class="btn-group">
                                 {{if and .HasUpdate (ne .Policy "pinned")}}
@@ -319,12 +322,13 @@
                                 {{end}}
                             </td>
                             <td></td>
+                            <td></td>
                         </tr>
                         {{end}}
                         {{else if eq .DesiredReplicas 0}}
                         <tr class="svc-task-row">
                             <td></td>
-                            <td colspan="4" class="text-muted" style="padding:var(--sp-3)">Service scaled to 0 &mdash; no active tasks</td>
+                            <td colspan="5" class="text-muted" style="padding:var(--sp-3)">Service scaled to 0 &mdash; no active tasks</td>
                             <td></td>
                         </tr>
                         {{end}}
@@ -441,8 +445,19 @@
                                         </span>
                                     {{end}}
                                 </td>
+                                <td class="cell-ports">
+                                    {{range .Ports}}
+                                        {{if .HostPort}}<span class="port-mapping" title="{{.HostIP}}:{{.HostPort}} → {{.ContainerPort}}/{{.Protocol}}">{{.HostPort}}:{{.ContainerPort}}</span>{{end}}
+                                    {{end}}
+                                </td>
                                 <td>
                                     <div class="btn-group">
+                                        {{if .WebURL}}
+                                        <a href="{{.WebURL}}" target="_blank" rel="noopener" class="btn btn-sm btn-open" onclick="event.stopPropagation()" title="Open in browser">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                                            Open
+                                        </a>
+                                        {{end}}
                                         {{if .IsSelf}}
                                             {{if and .HasUpdate (eq .HostID "")}}
                                             <button class="btn btn-info"

--- a/internal/web/static/src/css/dashboard.css
+++ b/internal/web/static/src/css/dashboard.css
@@ -749,6 +749,38 @@ table.managing .td-checkbox {
 
 
 /* --------------------------------------------------------------------------
+   24b. Port Mapping Column
+   -------------------------------------------------------------------------- */
+
+.cell-ports {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--fg-secondary);
+    white-space: nowrap;
+}
+
+.port-mapping {
+    display: inline-block;
+    padding: 1px 6px;
+    background: var(--bg-hover);
+    border-radius: var(--radius-sm);
+    margin: 1px 2px;
+    font-size: 0.7rem;
+    color: var(--fg-primary);
+}
+
+.btn-open {
+    gap: 4px;
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.btn-open:hover {
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+
+/* --------------------------------------------------------------------------
    25. Stack Row Animation
    -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
- Add PortMapping type and Ports field to ContainerSummary (web layer)
- Populate Ports via convertPorts() using container.PortSummary (SDK type rename)
- Add Ports/WebURL fields to containerView; containerWebURL() derives first HTTP link
- Dashboard table: Ports column with port-mapping chips, Open button for web-accessible containers
- CSS: .cell-ports, .port-mapping, .btn-open styles