### PR TITLE
fix: container detail shows wrong policy when no label set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,3 +438,10 @@ all settings, all auth
 ```bash
 make dev-deploy
 ```
+
+## Test Cluster Gotchas
+
+- **Setup wizard:** Fresh DB triggers wizard. Complete via `POST /api/setup` with `{"role":"server","username":"...","password":"..."}` (requires `role` field)
+- **Agent needs `SENTINEL_DB_PATH`:** Even in agent mode, the binary opens `/data/sentinel.db` by default. Always set `SENTINEL_DB_PATH=/tmp/sentinel-data/sentinel.db` for test deploys.
+- **Stale agent enrollment:** If the server is re-deployed fresh, agents with cached cluster data get x509 TLS errors. Wipe agent cluster dir (`rm -rf /tmp/sentinel-data/cluster`) before re-enrolling.
+- **SSH + nohup env vars:** Use heredoc (`ssh user@host bash << EOF`) not `bash -c` for multiple env var exports before nohup. Complex quoting in `bash -c` silently fails.

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -25,13 +25,17 @@ func containerName(c ContainerSummary) string {
 	return c.ID
 }
 
-// containerPolicy reads the sentinel.policy label, defaulting to "manual".
-func containerPolicy(labels map[string]string) string {
+// containerPolicy reads the sentinel.policy label, falling back to defaultPolicy.
+// If defaultPolicy is empty, falls back to "manual" for safety.
+func containerPolicy(labels map[string]string, defaultPolicy string) string {
 	if v, ok := labels["sentinel.policy"]; ok {
 		switch v {
 		case "auto", "manual", "pinned":
 			return v
 		}
+	}
+	if defaultPolicy != "" {
+		return defaultPolicy
 	}
 	return "manual"
 }
@@ -42,14 +46,18 @@ func (s *Server) isProtectedContainer(ctx context.Context, name string) bool {
 	return labels["sentinel.self"] == "true"
 }
 
-// resolvedPolicy returns the effective policy: DB override → label fallback.
+// resolvedPolicy returns the effective policy: DB override → label → global default.
 func (s *Server) resolvedPolicy(labels map[string]string, name string) string {
 	if s.deps.Policy != nil {
 		if p, ok := s.deps.Policy.GetPolicyOverride(name); ok {
 			return p
 		}
 	}
-	return containerPolicy(labels)
+	var defaultPolicy string
+	if s.deps.Config != nil {
+		defaultPolicy = s.deps.Config.DefaultPolicy()
+	}
+	return containerPolicy(labels, defaultPolicy)
 }
 
 // getContainerLabels fetches labels for a named container, checking local

--- a/internal/web/api_containers.go
+++ b/internal/web/api_containers.go
@@ -37,12 +37,7 @@ func (s *Server) apiContainers(w http.ResponseWriter, r *http.Request) {
 		}
 
 		name := containerName(c)
-		policy := containerPolicy(c.Labels)
-		if s.deps.Policy != nil {
-			if p, ok := s.deps.Policy.GetPolicyOverride(name); ok {
-				policy = p
-			}
-		}
+		policy := s.resolvedPolicy(c.Labels, name)
 
 		maintenance, err := s.deps.Store.GetMaintenance(name)
 		if err != nil {

--- a/internal/web/api_policy.go
+++ b/internal/web/api_policy.go
@@ -189,10 +189,7 @@ func (s *Server) apiBulkPolicy(w http.ResponseWriter, r *http.Request) {
 			policyKey = hid + "::" + name
 		}
 
-		current := containerPolicy(labels)
-		if p, ok := s.deps.Policy.GetPolicyOverride(policyKey); ok {
-			current = p
-		}
+		current := s.resolvedPolicy(labels, policyKey)
 
 		if current == body.Policy {
 			unchanged = append(unchanged, unchangedEntry{Name: name, Reason: "already " + body.Policy})

--- a/internal/web/api_policy_test.go
+++ b/internal/web/api_policy_test.go
@@ -616,3 +616,108 @@ func TestBulkPolicy_RemoteContainersScopedKeys(t *testing.T) {
 		t.Errorf("h1::postgres policy = (%q, %v), want (\"pinned\", true)", p, ok)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Mock: ConfigReader
+// ---------------------------------------------------------------------------
+
+type mockConfigReader struct {
+	values        map[string]string
+	defaultPolicy string
+}
+
+func (m *mockConfigReader) Values() map[string]string { return m.values }
+func (m *mockConfigReader) DefaultPolicy() string     { return m.defaultPolicy }
+
+// ---------------------------------------------------------------------------
+// containerPolicy tests (unit)
+// ---------------------------------------------------------------------------
+
+func TestContainerPolicy_LabelPresent(t *testing.T) {
+	labels := map[string]string{"sentinel.policy": "pinned"}
+	if got := containerPolicy(labels, "auto"); got != "pinned" {
+		t.Errorf("containerPolicy = %q, want %q", got, "pinned")
+	}
+}
+
+func TestContainerPolicy_NoLabel_UsesDefault(t *testing.T) {
+	if got := containerPolicy(nil, "auto"); got != "auto" {
+		t.Errorf("containerPolicy = %q, want %q", got, "auto")
+	}
+}
+
+func TestContainerPolicy_NoLabel_EmptyDefault(t *testing.T) {
+	if got := containerPolicy(nil, ""); got != "manual" {
+		t.Errorf("containerPolicy = %q, want %q (empty default → manual)", got, "manual")
+	}
+}
+
+func TestContainerPolicy_InvalidLabel_UsesDefault(t *testing.T) {
+	labels := map[string]string{"sentinel.policy": "yolo"}
+	if got := containerPolicy(labels, "auto"); got != "auto" {
+		t.Errorf("containerPolicy = %q, want %q (invalid label → default)", got, "auto")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolvedPolicy tests (integration with Config)
+// ---------------------------------------------------------------------------
+
+func TestResolvedPolicy_GlobalDefault(t *testing.T) {
+	// No label, no DB override, global default = "auto" → should return "auto".
+	srv := &Server{
+		deps: Dependencies{
+			Config: &mockConfigReader{defaultPolicy: "auto"},
+			Log:    slog.Default(),
+		},
+	}
+	got := srv.resolvedPolicy(nil, "nginx")
+	if got != "auto" {
+		t.Errorf("resolvedPolicy = %q, want %q", got, "auto")
+	}
+}
+
+func TestResolvedPolicy_LabelOverridesDefault(t *testing.T) {
+	srv := &Server{
+		deps: Dependencies{
+			Config: &mockConfigReader{defaultPolicy: "auto"},
+			Log:    slog.Default(),
+		},
+	}
+	labels := map[string]string{"sentinel.policy": "manual"}
+	got := srv.resolvedPolicy(labels, "nginx")
+	if got != "manual" {
+		t.Errorf("resolvedPolicy = %q, want %q", got, "manual")
+	}
+}
+
+func TestResolvedPolicy_DBOverridesLabel(t *testing.T) {
+	policy := newMockPolicyStore()
+	policy.overrides["nginx"] = "pinned"
+
+	srv := &Server{
+		deps: Dependencies{
+			Config: &mockConfigReader{defaultPolicy: "auto"},
+			Policy: policy,
+			Log:    slog.Default(),
+		},
+	}
+	labels := map[string]string{"sentinel.policy": "manual"}
+	got := srv.resolvedPolicy(labels, "nginx")
+	if got != "pinned" {
+		t.Errorf("resolvedPolicy = %q, want %q", got, "pinned")
+	}
+}
+
+func TestResolvedPolicy_NilConfig_FallsBackToManual(t *testing.T) {
+	// Backwards compat: no Config set → falls back to "manual".
+	srv := &Server{
+		deps: Dependencies{
+			Log: slog.Default(),
+		},
+	}
+	got := srv.resolvedPolicy(nil, "nginx")
+	if got != "manual" {
+		t.Errorf("resolvedPolicy = %q, want %q", got, "manual")
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -179,12 +179,7 @@ func (s *Server) handleContainerRow(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				s.deps.Log.Debug("failed to load maintenance state", "name", n, "error", err)
 			}
-			policy := containerPolicy(c.Labels)
-			if s.deps.Policy != nil {
-				if p, ok := s.deps.Policy.GetPolicyOverride(n); ok {
-					policy = p
-				}
-			}
+			policy := s.resolvedPolicy(c.Labels, n)
 			tag := registry.ExtractTag(c.Image)
 			if tag == "" {
 				if idx := strings.LastIndex(c.Image, "/"); idx >= 0 {
@@ -228,13 +223,7 @@ func (s *Server) handleContainerRow(w http.ResponseWriter, r *http.Request) {
 	if targetView == nil && s.deps.Cluster != nil && s.deps.Cluster.Enabled() {
 		for _, rc := range s.deps.Cluster.AllHostContainers() {
 			if rc.Name == name && (hostFilter == "" || rc.HostID == hostFilter) {
-				policy := containerPolicy(rc.Labels)
-				if s.deps.Policy != nil {
-					policyKey := rc.HostID + "::" + rc.Name
-					if p, ok := s.deps.Policy.GetPolicyOverride(policyKey); ok {
-						policy = p
-					}
-				}
+				policy := s.resolvedPolicy(rc.Labels, rc.HostID+"::"+rc.Name)
 				tag := registry.ExtractTag(rc.Image)
 				if tag == "" {
 					if idx := strings.LastIndex(rc.Image, "/"); idx >= 0 {
@@ -521,13 +510,7 @@ func (s *Server) handleContainerDetail(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		policy := containerPolicy(rc.Labels)
-		if s.deps.Policy != nil {
-			policyKey := rc.HostID + "::" + rc.Name
-			if p, ok := s.deps.Policy.GetPolicyOverride(policyKey); ok {
-				policy = p
-			}
-		}
+		policy := s.resolvedPolicy(rc.Labels, rc.HostID+"::"+rc.Name)
 		tag := registry.ExtractTag(rc.Image)
 		if tag == "" {
 			if idx := strings.LastIndex(rc.Image, "/"); idx >= 0 {
@@ -600,12 +583,7 @@ func (s *Server) handleContainerDetail(w http.ResponseWriter, r *http.Request) {
 			s.deps.Log.Debug("failed to load maintenance state", "name", name, "error", err)
 		}
 
-		detailPolicy := containerPolicy(found.Labels)
-		if s.deps.Policy != nil {
-			if p, ok := s.deps.Policy.GetPolicyOverride(name); ok {
-				detailPolicy = p
-			}
-		}
+		detailPolicy := s.resolvedPolicy(found.Labels, name)
 
 		detailTag := registry.ExtractTag(found.Image)
 		if detailTag == "" {

--- a/internal/web/handlers_dashboard.go
+++ b/internal/web/handlers_dashboard.go
@@ -166,12 +166,7 @@ type taskView struct {
 // the local host). Used by the dashboard, API, and service detail handlers.
 func (s *Server) buildServiceView(d ServiceDetail, pendingNames map[string]bool, hostAddr string) serviceView {
 	name := d.Name
-	policy := containerPolicy(d.Labels)
-	if s.deps.Policy != nil {
-		if p, ok := s.deps.Policy.GetPolicyOverride(name); ok {
-			policy = p
-		}
-	}
+	policy := s.resolvedPolicy(d.Labels, name)
 	tag := registry.ExtractTag(d.Image)
 	if tag == "" {
 		if idx := strings.LastIndex(d.Image, "/"); idx >= 0 {
@@ -355,12 +350,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			s.deps.Log.Debug("failed to load maintenance state", "name", name, "error", err)
 		}
 
-		policy := containerPolicy(c.Labels)
-		if s.deps.Policy != nil {
-			if p, ok := s.deps.Policy.GetPolicyOverride(name); ok {
-				policy = p
-			}
-		}
+		policy := s.resolvedPolicy(c.Labels, name)
 
 		// Extract tag for compact display; fall back to last path segment.
 		tag := registry.ExtractTag(c.Image)
@@ -612,13 +602,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			}
 			// Resolve policy the same way we do for local containers:
 			// label first, then DB override (keyed by hostID::name for remote).
-			policy := containerPolicy(rc.Labels)
-			if s.deps.Policy != nil {
-				policyKey := rc.HostID + "::" + rc.Name
-				if p, ok := s.deps.Policy.GetPolicyOverride(policyKey); ok {
-					policy = p
-				}
-			}
+			policy := s.resolvedPolicy(rc.Labels, rc.HostID+"::"+rc.Name)
 
 			var newestVersion string
 			var hasUpdate bool

--- a/internal/web/interfaces.go
+++ b/internal/web/interfaces.go
@@ -582,6 +582,7 @@ type VersionScopeUpdater interface {
 // ConfigReader provides settings for display.
 type ConfigReader interface {
 	Values() map[string]string
+	DefaultPolicy() string
 }
 
 // ConfigWriter updates mutable runtime settings in memory.


### PR DESCRIPTION
## Summary
- Container detail page showed "manual" for containers with no `sentinel.policy` Docker label, even when the global default was "auto" (#57, reported in #53)
- Root cause: `containerPolicy()` hard-coded `"manual"` as the fallback, ignoring the global default policy
- Added `DefaultPolicy() string` to `ConfigReader` interface so the web layer can read the global default
- Changed `containerPolicy()` to accept a `defaultPolicy` parameter
- Replaced all 9 inline "containerPolicy + DB override" patterns with centralised `resolvedPolicy()` calls
- Policy precedence now matches the engine: DB override > Docker label > global default
- Added 8 new tests covering the full precedence chain

Closes #57

## Test plan
- [x] All tests pass locally (`go test ./...`)
- [x] Lint clean (`make lint`)
- [x] New tests verify: label present, no label with default, no label with empty default, invalid label, global default, label overrides default, DB overrides label, nil config backwards compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)