### PR TITLE
chore: add community docs, templates, and repo config

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,13 @@
+title: "[Idea] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    attributes:
+      label: Idea
+      description: Describe your idea or suggestion.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Use case
+      description: What problem would this solve for you?

--- a/.github/DISCUSSION_TEMPLATE/questions.yml
+++ b/.github/DISCUSSION_TEMPLATE/questions.yml
@@ -1,0 +1,17 @@
+title: "[Q&A] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking a question. Please check the [wiki](https://github.com/Will-Luck/Docker-Sentinel/wiki) first.
+  - type: textarea
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Sentinel version
+      placeholder: "e.g. v2.10.0"

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,8 @@
+title: "[Show] "
+body:
+  - type: textarea
+    attributes:
+      label: What did you build or set up?
+      description: Share your Docker-Sentinel setup, integrations, or customisations.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in Docker-Sentinel
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the form below as completely as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear summary of the bug.
+      placeholder: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Start Sentinel with config...
+        2. Navigate to...
+        3. Click on...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened instead.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Sentinel version
+      description: The version of Docker-Sentinel you are running.
+      placeholder: "e.g. v2.10.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment method
+      description: How are you running Docker-Sentinel?
+      options:
+        - Docker
+        - Binary
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Details about your system.
+      placeholder: |
+        OS: Ubuntu 24.04
+        Docker: 27.1.0
+        Architecture: amd64
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log output from Docker-Sentinel. This will be rendered as a code block automatically.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and Support
+    url: https://github.com/Will-Luck/Docker-Sentinel/discussions/categories/q-a
+    about: Ask questions and get help in Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement for Docker-Sentinel
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for Docker-Sentinel? Describe it below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: What problem does this solve? Why is this feature needed?
+      placeholder: I find it difficult to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work? Be as specific as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative approaches or workarounds?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information, screenshots, or references that might be helpful.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Changes checklist
+
+- [ ] Tests pass (`make test`)
+- [ ] Lint is clean (`make lint`)
+- [ ] CHANGELOG updated (if user-facing change)
+- [ ] Screenshots attached (if UI changes)
+
+## Related issues
+
+<!-- Link related issues below. Use "Closes #123" to auto-close on merge. -->
+
+Closes #

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: Security
+      labels:
+        - security
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, colour, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported by contacting the project team at **conduct@pphserv.uk**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Docker-Sentinel
+
+Thanks for your interest in contributing. This guide covers everything you need to get started.
+
+## Prerequisites
+
+- **Go 1.24+**
+- **Docker** (for integration tests and building images)
+- **Node.js** (for esbuild frontend bundling)
+
+## Building
+
+```bash
+make build          # Build the Go binary
+make frontend       # Bundle frontend assets (esbuild)
+make test           # Run tests
+make lint           # Run golangci-lint
+```
+
+## Project Structure
+
+The web frontend is modular. Source files live in `static/src/js/` and `static/src/css/`, and esbuild bundles them into `static/app.js` and `static/style.css`.
+
+**Never edit `static/app.js` or `static/style.css` directly.** These are build artefacts. Edit the source modules and run `make frontend` to rebuild.
+
+## Code Style
+
+- UK English throughout (code comments, UI strings, documentation)
+- Run `make lint` before every commit. Formatting failures are the most common CI issue.
+- All code is licensed under Apache 2.0. By contributing, you agree your contributions are under the same licence.
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch from `dev`
+3. Make your changes
+4. Include tests for new features or bug fixes
+5. Run `make test` and `make lint` to verify everything passes
+6. Open a PR against the `dev` branch
+
+PRs against `main` will be closed. All changes go through `dev` first.
+
+## Commit Messages
+
+Use conventional commits:
+
+```
+feat: add webhook retry logic
+fix: correct image tag parsing for GHCR
+docs: update configuration examples
+test: add coverage for policy engine
+refactor: extract registry client into separate package
+```
+
+Keep the subject line under 72 characters. Add a body if the change needs explanation.
+
+## Reporting Bugs
+
+Open a GitHub issue with:
+
+- Docker-Sentinel version
+- Docker version and host OS
+- Steps to reproduce
+- Expected vs actual behaviour
+- Relevant log output (with sensitive data redacted)
+
+## Questions
+
+Open a GitHub Discussion or issue. We are happy to help.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Docker-Sentinel
 
-[![CI](https://github.com/Will-Luck/Docker-Sentinel/actions/workflows/release.yml/badge.svg)](https://github.com/Will-Luck/Docker-Sentinel/actions/workflows/release.yml)
-[![GitHub Release](https://img.shields.io/github/v/release/Will-Luck/Docker-Sentinel)](https://github.com/Will-Luck/Docker-Sentinel/releases/latest)
-[![Licence](https://img.shields.io/github/license/Will-Luck/Docker-Sentinel)](LICENSE)
+[![CI](https://github.com/Will-Luck/Docker-Sentinel/actions/workflows/ci.yml/badge.svg)](https://github.com/Will-Luck/Docker-Sentinel/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/Will-Luck/Docker-Sentinel)](https://github.com/Will-Luck/Docker-Sentinel/releases/latest)
+[![License](https://img.shields.io/github/license/Will-Luck/Docker-Sentinel)](LICENSE)
+[![Go](https://img.shields.io/github/go-mod/go-version/Will-Luck/Docker-Sentinel)](go.mod)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Will-Luck/Docker-Sentinel)](https://goreportcard.com/report/github.com/Will-Luck/Docker-Sentinel)
+[![GHCR](https://img.shields.io/badge/ghcr.io-docker--sentinel-blue)](https://github.com/Will-Luck/Docker-Sentinel/pkgs/container/docker-sentinel)
 
 A container update orchestrator with a web dashboard, written in Go. Replaces Watchtower with per-container update policies, pre-update snapshots, automatic rollback, and real-time notifications.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| v2.10.x  | Yes                |
+| < v2.10  | No                 |
+
+Only the latest minor release receives security patches. Please upgrade to the latest version before reporting issues.
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Email **security@pphserv.uk** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Affected version(s)
+- Any potential impact assessment
+
+## Response Timeline
+
+- **Acknowledgement:** Within 48 hours of report
+- **Initial assessment:** Within 7 days
+- **Fix for critical issues:** Within 30 days
+- **Fix for non-critical issues:** Included in the next scheduled release
+
+You will be credited in the release notes unless you request otherwise.
+
+## Scope
+
+This policy covers the Docker-Sentinel application and its official container images published to GHCR. Third-party forks and distributions are outside scope.


### PR DESCRIPTION
## Summary

- Add issue templates (bug report, feature request) with YAML form format
- Add PR template with checklist
- Add discussion templates (questions, ideas, show and tell)
- Add SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md
- Add release notes auto-categorisation config
- Update README with Go version, Go Report Card, and GHCR badges

## Test plan

- [ ] Issue templates render correctly on GitHub (New Issue page)
- [ ] PR template loads when creating a new PR
- [ ] Discussion templates appear in Discussions tab
- [ ] README badges resolve and display correctly