### PR TITLE
docs: add download count badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Go](https://img.shields.io/github/go-mod/go-version/Will-Luck/Docker-Sentinel)](go.mod)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Will-Luck/Docker-Sentinel)](https://goreportcard.com/report/github.com/Will-Luck/Docker-Sentinel)
 [![GHCR](https://img.shields.io/badge/ghcr.io-docker--sentinel-blue)](https://github.com/Will-Luck/Docker-Sentinel/pkgs/container/docker-sentinel)
+[![GitHub Downloads](https://img.shields.io/github/downloads/Will-Luck/Docker-Sentinel/total)](https://github.com/Will-Luck/Docker-Sentinel/releases)
+[![GHCR Pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fipitio.github.io%2Fbackage%2FWill-Luck%2FDocker-Sentinel%2Fdocker-sentinel.json&query=%24.downloads&label=ghcr%20pulls)](https://github.com/Will-Luck/Docker-Sentinel/pkgs/container/docker-sentinel)
 
 A container update orchestrator with a web dashboard, written in Go. Replaces Watchtower with per-container update policies, pre-update snapshots, automatic rollback, and real-time notifications.
 


### PR DESCRIPTION
## Summary

- Add GitHub release download count badge (total across all releases)
- Add GHCR container pull count badge (via ipitio/backage)

## Test plan

- [ ] Both badges render on the README
- [ ] GitHub Downloads badge links to releases page
- [ ] GHCR Pulls badge links to container package page