### PR TITLE
feat: clearer outcome labels, tooltips, and scan summary row

### DIFF
--- a/internal/engine/update.go
+++ b/internal/engine/update.go
@@ -129,7 +129,7 @@ func (u *Updater) UpdateContainer(ctx context.Context, id, name, targetImage str
 			OldDigest:     oldImageID,
 			NewImage:      pullImage,
 			NewDigest:     newImageID,
-			Outcome:       "no_change",
+			Outcome:       "identical",
 			Duration:      duration,
 		})
 		// Cache digest equivalence so future scans skip this pair.
@@ -336,7 +336,7 @@ func (u *Updater) UpdateContainer(ctx context.Context, id, name, targetImage str
 			OldDigest:     extractDigestForRecord(inspect),
 			NewImage:      pullImage,
 			NewDigest:     newDigest,
-			Outcome:       "finalise_warning",
+			Outcome:       "partial",
 			Duration:      duration,
 			Error:         finaliseErr.Error(),
 		}); recErr != nil {

--- a/internal/engine/updater_scan.go
+++ b/internal/engine/updater_scan.go
@@ -36,6 +36,7 @@ type ScanResult struct {
 	Updated     int
 	Failed      int
 	RateLimited int // containers skipped due to rate limits
+	UpToDate    int // containers where the registry confirmed no update
 	Errors      []error
 
 	// Swarm service stats (only populated when Swarm mode is active).
@@ -468,7 +469,7 @@ func (u *Updater) Scan(ctx context.Context, mode ScanMode) ScanResult {
 					Timestamp:     u.clock.Now(),
 					ContainerName: name,
 					OldImage:      imageRef,
-					Outcome:       "skipped",
+					Outcome:       "rate_limited",
 					Error:         "rate limit low on " + host,
 				})
 				result.RateLimited++
@@ -487,7 +488,7 @@ func (u *Updater) Scan(ctx context.Context, mode ScanMode) ScanResult {
 				Timestamp:     u.clock.Now(),
 				ContainerName: name,
 				OldImage:      imageRef,
-				Outcome:       "skipped",
+				Outcome:       "check_failed",
 				Error:         check.Error.Error(),
 			})
 			result.Errors = append(result.Errors, fmt.Errorf("%s: %w", name, check.Error))
@@ -511,6 +512,7 @@ func (u *Updater) Scan(ctx context.Context, mode ScanMode) ScanResult {
 				u.log.Info("removed stale queue entry (now up to date)", "name", name)
 			}
 			u.log.Debug("up to date", "name", name, "image", imageRef)
+			result.UpToDate++
 			continue
 		}
 
@@ -793,6 +795,16 @@ func (u *Updater) Scan(ctx context.Context, mode ScanMode) ScanResult {
 	metrics.ContainersMonitored.Set(float64(result.Total - result.Skipped))
 	metrics.PendingUpdates.Set(float64(result.Queued))
 	metrics.ScanDuration.Observe(time.Since(scanStart).Seconds())
+
+	// Record scan summary in history.
+	_ = u.store.RecordUpdate(store.UpdateRecord{
+		Timestamp: u.clock.Now(),
+		Outcome:   "scan_summary",
+		Type:      "scan",
+		Error: fmt.Sprintf("%d checked, %d up to date, %d updated, %d queued, %d skipped, %d failed",
+			result.Total-result.Skipped, result.UpToDate, result.Updated, result.Queued, result.RateLimited, result.Failed),
+		Duration: time.Since(scanStart),
+	})
 
 	// Publish HA discovery states after scan.
 	if u.haDiscovery != nil {

--- a/internal/engine/updater_test.go
+++ b/internal/engine/updater_test.go
@@ -634,7 +634,7 @@ func setupUpdateMock(t *testing.T) (*mockDocker, *Updater) {
 
 // TestUpdateFinaliseStopFailureRecordsWarning tests the non-destructive path:
 // finalise stop fails, so the container is still running (with maintenance label).
-// Should record "finalise_warning" and NOT attempt rollback.
+// Should record "partial" and NOT attempt rollback.
 func TestUpdateFinaliseStopFailureRecordsWarning(t *testing.T) {
 	mock, u := setupUpdateMock(t)
 
@@ -662,7 +662,7 @@ func TestUpdateFinaliseStopFailureRecordsWarning(t *testing.T) {
 		t.Errorf("createCalls = %d, want 1 (no rollback on non-destructive finalise failure)", len(mock.createCalls))
 	}
 
-	// Verify update was recorded as "finalise_warning" (not "success").
+	// Verify update was recorded as "partial" (not "success").
 	history, hErr := u.store.ListHistory(10, "")
 	if hErr != nil {
 		t.Fatalf("ListHistory: %v", hErr)
@@ -670,8 +670,8 @@ func TestUpdateFinaliseStopFailureRecordsWarning(t *testing.T) {
 	if len(history) != 1 {
 		t.Fatalf("history len = %d, want 1", len(history))
 	}
-	if history[0].Outcome != "finalise_warning" {
-		t.Errorf("outcome = %q, want %q", history[0].Outcome, "finalise_warning")
+	if history[0].Outcome != "partial" {
+		t.Errorf("outcome = %q, want %q", history[0].Outcome, "partial")
 	}
 	if history[0].Error == "" {
 		t.Error("error field should be non-empty for finalise_warning")
@@ -975,7 +975,7 @@ func TestUpdateContainerImageIDGuardSkipsNoChange(t *testing.T) {
 		t.Errorf("startCalls = %d, want 0", len(mock.startCalls))
 	}
 
-	// History should show "no_change" outcome.
+	// History should show "identical" outcome.
 	history, hErr := u.store.ListHistory(10, "")
 	if hErr != nil {
 		t.Fatalf("ListHistory: %v", hErr)
@@ -983,8 +983,8 @@ func TestUpdateContainerImageIDGuardSkipsNoChange(t *testing.T) {
 	if len(history) != 1 {
 		t.Fatalf("history len = %d, want 1", len(history))
 	}
-	if history[0].Outcome != "no_change" {
-		t.Errorf("outcome = %q, want %q", history[0].Outcome, "no_change")
+	if history[0].Outcome != "identical" {
+		t.Errorf("outcome = %q, want %q", history[0].Outcome, "identical")
 	}
 }
 

--- a/internal/store/bolt.go
+++ b/internal/store/bolt.go
@@ -112,7 +112,7 @@ type UpdateRecord struct {
 	OldDigest     string        `json:"old_digest"`
 	NewImage      string        `json:"new_image"`
 	NewDigest     string        `json:"new_digest"`
-	Outcome       string        `json:"outcome"` // "success", "rollback", "failed", or "finalise_warning"
+	Outcome       string        `json:"outcome"` // "success", "failed", "rollback", "identical", "partial", "rate_limited", "check_failed", "dry_run", "pull_only", "scan_summary"
 	Duration      time.Duration `json:"duration"`
 	Error         string        `json:"error,omitempty"`
 	Type          string        `json:"type,omitempty"`      // "container" (default) or "service"

--- a/internal/web/interfaces.go
+++ b/internal/web/interfaces.go
@@ -435,7 +435,7 @@ type UpdateRecord struct {
 	OldDigest     string        `json:"old_digest"`
 	NewImage      string        `json:"new_image"`
 	NewDigest     string        `json:"new_digest"`
-	Outcome       string        `json:"outcome"`
+	Outcome       string        `json:"outcome"` // "success", "failed", "rollback", "identical", "partial", "rate_limited", "check_failed", "dry_run", "pull_only", "scan_summary"
 	Duration      time.Duration `json:"duration"`
 	Error         string        `json:"error,omitempty"`
 	Type          string        `json:"type,omitempty"`      // "container" (default) or "service"

--- a/internal/web/static/container.html
+++ b/internal/web/static/container.html
@@ -281,9 +281,15 @@
                                     <td class="cell-image mono">{{.OldImage}}</td>
                                     <td class="cell-image mono">{{.NewImage}}</td>
                                     <td>
-                                        {{if eq .Outcome "success"}}<span class="badge badge-success">Success</span>
-                                        {{else if eq .Outcome "rollback"}}<span class="badge badge-error">Rollback</span>
-                                        {{else if eq .Outcome "skipped"}}<span class="badge badge-warning">Skipped</span>
+                                        {{if eq .Outcome "success"}}<span class="badge badge-success" title="Container updated and running healthy">Updated</span>
+                                        {{else if eq .Outcome "rollback"}}<span class="badge badge-error" title="Update failed health check, restored previous version">Rolled Back</span>
+                                        {{else if eq .Outcome "rollback_success"}}<span class="badge badge-warning" title="Successfully restored previous version">Rollback OK</span>
+                                        {{else if eq .Outcome "rollback_failed"}}<span class="badge badge-error" title="Attempted rollback but restoration also failed">Rollback Failed</span>
+                                        {{else if eq .Outcome "failed"}}<span class="badge badge-error" title="Update failed, container may be unhealthy">Failed</span>
+                                        {{else if eq .Outcome "rate_limited"}}<span class="badge badge-warning" title="Registry throttled the request, will retry next scan">Rate Limited</span>
+                                        {{else if eq .Outcome "check_failed"}}<span class="badge badge-warning" title="Could not reach the registry to check for updates">Check Failed</span>
+                                        {{else if eq .Outcome "identical"}}<span class="badge badge-info" title="New image was pulled but is identical to the current one">Image Identical</span>
+                                        {{else if eq .Outcome "partial"}}<span class="badge badge-warning" title="Container updated but post-update cleanup had issues">Updated (partial)</span>
                                         {{else}}<span class="badge badge-muted">{{.Outcome}}</span>{{end}}
                                     </td>
                                     <td class="mono">{{fmtDuration .Duration}}</td>

--- a/internal/web/static/history.html
+++ b/internal/web/static/history.html
@@ -76,10 +76,11 @@
 
         <div class="filter-bar" id="history-filter-bar">
             <button class="filter-pill history-filter-pill active" data-outcome="all" onclick="filterHistory('all')">All</button>
-            <button class="filter-pill history-filter-pill" data-outcome="success" onclick="filterHistory('success')">Success</button>
+            <button class="filter-pill history-filter-pill" data-outcome="success" onclick="filterHistory('success')">Updated</button>
             <button class="filter-pill history-filter-pill" data-outcome="failed" onclick="filterHistory('failed')">Failed</button>
             <button class="filter-pill history-filter-pill" data-outcome="rollback" onclick="filterHistory('rollback')">Rollback</button>
             <button class="filter-pill history-filter-pill" data-outcome="skipped" onclick="filterHistory('skipped')">Skipped</button>
+            <button class="filter-pill history-filter-pill" data-outcome="identical" onclick="filterHistory('identical')">Identical</button>
             <button class="filter-pill history-filter-pill" data-outcome="other" onclick="filterHistory('other')">Other</button>
         </div>
 
@@ -103,7 +104,7 @@
                             {{range $i, $r := .History}}
                             <tr class="container-row history-row" data-outcome="{{$r.Outcome}}" onclick="onRowClick(event, 'history-{{$i}}')">
                                 <td title="{{fmtTime $r.Timestamp}}">{{fmtTimeAgo $r.Timestamp}}</td>
-                                <td><a href="{{serviceOrContainer $r.Type $r.ContainerName $r.HostID}}" class="container-link">{{$r.ContainerName}}</a>{{if .HostName}}<span class="host-badge" title="Host: {{.HostName}}">{{.HostName}}</span>{{end}}</td>
+                                <td>{{if eq $r.Outcome "scan_summary"}}{{if $r.Error}}{{$r.Error}}{{else}}&mdash;{{end}}{{else}}<a href="{{serviceOrContainer $r.Type $r.ContainerName $r.HostID}}" class="container-link">{{$r.ContainerName}}</a>{{if .HostName}}<span class="host-badge" title="Host: {{.HostName}}">{{.HostName}}</span>{{end}}{{end}}</td>
                                 <td class="cell-image mono">
                                     {{$oldTag := imageTag $r.OldImage}}{{$newTag := imageTag $r.NewImage}}
                                     {{if and $oldTag $newTag (ne $oldTag $newTag)}}
@@ -119,25 +120,29 @@
                                 </td>
                                 <td>
                                     {{if eq $r.Outcome "success"}}
-                                        <span class="badge badge-success">Success</span>
+                                        <span class="badge badge-success" title="Container updated and running healthy">Updated</span>
                                     {{else if eq $r.Outcome "rollback"}}
-                                        <span class="badge badge-error">Rollback</span>
+                                        <span class="badge badge-error" title="Update failed health check, restored previous version">Rolled Back</span>
                                     {{else if eq $r.Outcome "rollback_success"}}
-                                        <span class="badge badge-warning">Rollback OK</span>
+                                        <span class="badge badge-warning" title="Successfully restored previous version">Rollback OK</span>
                                     {{else if eq $r.Outcome "rollback_failed"}}
-                                        <span class="badge badge-error">Rollback Failed</span>
+                                        <span class="badge badge-error" title="Attempted rollback but restoration also failed">Rollback Failed</span>
                                     {{else if eq $r.Outcome "failed"}}
-                                        <span class="badge badge-error">Failed</span>
-                                    {{else if eq $r.Outcome "finalise_warning"}}
-                                        <span class="badge badge-warning">Warning</span>
-                                    {{else if eq $r.Outcome "skipped"}}
-                                        <span class="badge badge-warning">Skipped</span>
+                                        <span class="badge badge-error" title="Update failed, container may be unhealthy">Failed</span>
+                                    {{else if eq $r.Outcome "partial"}}
+                                        <span class="badge badge-warning" title="Container updated but post-update cleanup had issues">Updated (partial)</span>
+                                    {{else if eq $r.Outcome "rate_limited"}}
+                                        <span class="badge badge-warning" title="Registry throttled the request, will retry next scan">Rate Limited</span>
+                                    {{else if eq $r.Outcome "check_failed"}}
+                                        <span class="badge badge-warning" title="Could not reach the registry to check for updates">Check Failed</span>
                                     {{else if eq $r.Outcome "dry_run"}}
-                                        <span class="badge badge-muted">Dry Run</span>
+                                        <span class="badge badge-muted" title="Would have updated in normal mode (dry run enabled)">Simulated</span>
                                     {{else if eq $r.Outcome "pull_only"}}
-                                        <span class="badge badge-muted">Pull Only</span>
-                                    {{else if eq $r.Outcome "no_change"}}
-                                        <span class="badge badge-info">No Change</span>
+                                        <span class="badge badge-muted" title="Image pulled but container was not restarted">Pulled</span>
+                                    {{else if eq $r.Outcome "identical"}}
+                                        <span class="badge badge-info" title="New image was pulled but is identical to the current one">Image Identical</span>
+                                    {{else if eq $r.Outcome "scan_summary"}}
+                                        <span class="badge badge-info" title="Summary of the last completed scan">Scan Summary</span>
                                     {{else}}
                                         <span class="badge badge-muted">{{$r.Outcome}}</span>
                                     {{end}}
@@ -204,10 +209,11 @@
 
     var OUTCOME_GROUPS = {
         success:  ['success'],
-        failed:   ['failed', 'rollback_failed'],
-        rollback: ['rollback', 'rollback_success'],
-        skipped:  ['skipped'],
-        other:    ['dry_run', 'pull_only', 'finalise_warning', 'no_change']
+        failed:   ['failed'],
+        rollback: ['rollback', 'rollback_success', 'rollback_failed'],
+        skipped:  ['rate_limited', 'check_failed'],
+        identical: ['identical'],
+        other:    ['dry_run', 'pull_only', 'partial', 'scan_summary']
     };
 
     function filterHistory(filter) {
@@ -275,11 +281,15 @@
                     tdTime.textContent = ago;
 
                     var tdName = document.createElement('td');
-                    var link = document.createElement('a');
-                    link.href = '/container/' + encodeURIComponent(r.container_name);
-                    link.className = 'container-link';
-                    link.textContent = r.container_name;
-                    tdName.appendChild(link);
+                    if (r.outcome === 'scan_summary') {
+                        tdName.textContent = r.error || '\u2014';
+                    } else {
+                        var link = document.createElement('a');
+                        link.href = '/container/' + encodeURIComponent(r.container_name);
+                        link.className = 'container-link';
+                        link.textContent = r.container_name;
+                        tdName.appendChild(link);
+                    }
 
                     var tdVersion = document.createElement('td');
                     tdVersion.className = 'cell-image mono';
@@ -375,13 +385,15 @@
     }
 
     function badgeForHist(outcome) {
-        var map = {success:'badge-success',rollback:'badge-error',rollback_success:'badge-warning',rollback_failed:'badge-error',failed:'badge-error',finalise_warning:'badge-warning',skipped:'badge-warning',dry_run:'badge-muted',pull_only:'badge-muted',no_change:'badge-info'};
-        var label = {success:'Success',rollback:'Rollback',rollback_success:'Rollback OK',rollback_failed:'Rollback Failed',failed:'Failed',finalise_warning:'Warning',skipped:'Skipped',dry_run:'Dry Run',pull_only:'Pull Only',no_change:'No Change'};
+        var map = {success:'badge-success',rollback:'badge-error',rollback_success:'badge-warning',rollback_failed:'badge-error',failed:'badge-error',partial:'badge-warning',rate_limited:'badge-warning',check_failed:'badge-warning',dry_run:'badge-muted',pull_only:'badge-muted',identical:'badge-info',scan_summary:'badge-info'};
+        var label = {success:'Updated',rollback:'Rolled Back',rollback_success:'Rollback OK',rollback_failed:'Rollback Failed',failed:'Failed',partial:'Updated (partial)',rate_limited:'Rate Limited',check_failed:'Check Failed',dry_run:'Simulated',pull_only:'Pulled',identical:'Image Identical',scan_summary:'Scan Summary'};
+        var tips = {success:'Container updated and running healthy',rollback:'Update failed health check, restored previous version',rollback_success:'Successfully restored previous version',rollback_failed:'Attempted rollback but restoration also failed',failed:'Update failed, container may be unhealthy',partial:'Container updated but post-update cleanup had issues',rate_limited:'Registry throttled the request, will retry next scan',check_failed:'Could not reach the registry to check for updates',dry_run:'Would have updated in normal mode (dry run enabled)',pull_only:'Image pulled but container was not restarted',identical:'New image was pulled but is identical to the current one',scan_summary:'Summary of the last completed scan'};
         var cls = map[outcome] || 'badge-muted';
         var txt = label[outcome] || outcome;
         var span = document.createElement('span');
         span.className = 'badge ' + cls;
         span.textContent = txt;
+        if (tips[outcome]) span.title = tips[outcome];
         return span;
     }
 

--- a/internal/web/static/service.html
+++ b/internal/web/static/service.html
@@ -263,13 +263,16 @@
                                     <td class="mono cell-image">{{imageTag .OldImage}}</td>
                                     <td class="mono cell-image">{{imageTag .NewImage}}</td>
                                     <td>
-                                        {{if eq .Outcome "success"}}
-                                            <span class="badge badge-success">Success</span>
-                                        {{else if eq .Outcome "rollback"}}
-                                            <span class="badge badge-error">Rollback</span>
-                                        {{else}}
-                                            <span class="badge badge-muted">{{.Outcome}}</span>
-                                        {{end}}
+                                        {{if eq .Outcome "success"}}<span class="badge badge-success" title="Container updated and running healthy">Updated</span>
+                                        {{else if eq .Outcome "rollback"}}<span class="badge badge-error" title="Update failed health check, restored previous version">Rolled Back</span>
+                                        {{else if eq .Outcome "rollback_success"}}<span class="badge badge-warning" title="Successfully restored previous version">Rollback OK</span>
+                                        {{else if eq .Outcome "rollback_failed"}}<span class="badge badge-error" title="Attempted rollback but restoration also failed">Rollback Failed</span>
+                                        {{else if eq .Outcome "failed"}}<span class="badge badge-error" title="Update failed, container may be unhealthy">Failed</span>
+                                        {{else if eq .Outcome "rate_limited"}}<span class="badge badge-warning" title="Registry throttled the request, will retry next scan">Rate Limited</span>
+                                        {{else if eq .Outcome "check_failed"}}<span class="badge badge-warning" title="Could not reach the registry to check for updates">Check Failed</span>
+                                        {{else if eq .Outcome "identical"}}<span class="badge badge-info" title="New image was pulled but is identical to the current one">Image Identical</span>
+                                        {{else if eq .Outcome "partial"}}<span class="badge badge-warning" title="Container updated but post-update cleanup had issues">Updated (partial)</span>
+                                        {{else}}<span class="badge badge-muted">{{.Outcome}}</span>{{end}}
                                     </td>
                                     <td class="mono">{{fmtDuration .Duration}}</td>
                                 </tr>


### PR DESCRIPTION
## Summary

- Rename outcome strings for clarity: `no_change` → `identical`, `finalise_warning` → `partial`, split `skipped` into `rate_limited` and `check_failed`
- All history badges now show descriptive labels (Updated, Rolled Back, Image Identical, Rate Limited, Check Failed, etc.)
- Every badge has a hover tooltip explaining what the outcome means in plain English
- New scan summary row after each scan showing counts: checked, up to date, updated, queued, skipped, failed
- New "Identical" filter pill on history page
- Same tooltip treatment on container detail and service detail pages

Addresses feedback from #62 and #63.

## Test plan

- [x] All Go tests pass
- [x] golangci-lint clean
- [x] Deployed to .57 and verified dashboard, history page, scan summary row
- [x] Tooltips visible on hover for all badge types
- [x] Filter pills work with new outcome groupings